### PR TITLE
Remove exception when a duplicate service key is encountered.

### DIFF
--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -161,3 +161,53 @@ class ModuleFour implements ExecutableModule
     }
 }
 ```
+### Service/Factory overrides
+When the same Service id is registered more than once by multiple modules, the latter will override the former.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Inpsyde\Modularity\Module\ServiceModule;
+use Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
+use Psr\Container\ContainerInterface;
+
+class ModuleWhichProvidesServices implements ServiceModule
+{
+    use ModuleClassNameIdTrait;
+
+    public function services() : array
+    {
+        return [
+            ServiceOne::class => static function(ContainerInterface $container): ServiceOne {
+                return new ServiceOne();
+            } 
+        ];
+    }
+}
+
+class ModuleWhichOverridesServices implements ServiceModule
+{
+    use ModuleClassNameIdTrait;
+
+    public function services() : array
+    {
+        return [
+            ServiceOne::class => static function(ContainerInterface $container): ServiceOne {
+                return new class extends ServiceOne{
+                    /*  */
+                };
+            } 
+        ];
+    }
+}
+```
+
+*For module developers* this opens up some possibilities, like the ability to inject Mocks in the container, or work around 
+scenarios where the use of extensions would result in an unneeded and/or wasteful constructor call of the now-obsolete
+original.
+
+*For package maintainers* this is something to watch out for when consuming Modules from multiple sources. 
+However unlikely it may be, there is a risk of _unintentional_ overrides resulting in unexpected behaviour.
+

--- a/src/Container/ContainerConfigurator.php
+++ b/src/Container/ContainerConfigurator.php
@@ -74,10 +74,18 @@ class ContainerConfigurator
     public function addService(string $id, callable $service): void
     {
         if ($this->hasService($id)) {
-            throw new class ("Service with ID {$id} is already registered.")
-                extends \Exception
-                implements ContainerExceptionInterface {
-            };
+            /*
+             * We are being intentionally permissive here,
+             * allowing a simple workflow for *intentional* overrides
+             * while accepting the (small?) risk of *accidental* overrides
+             * that could be hard to notice and debug.
+             */
+
+            /*
+             * Clear a factory flag in case it was a factory.
+             * If needs be, it will get re-added after this function completes.
+             */
+            unset($this->factoryIds[$id]);
         }
 
         $this->services[$id] = $service;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It removes the Exception thrown when a duplicate service ID is encountered. This made it impossible to inject mocks on the boundaries of the application for functional tests. It also prevented a couple of use-cases and patterns during runtime that required explicit workarounds or potentially wasteful usage of [extensions](https://github.com/inpsyde/modularity/blob/64049e964d894282f03b75946badfc0fca87884f/docs/Modules.md#extendingmodule)


**What is the current behavior?** (You can also link to an open issue here)

It is not possible to override a previously registered service from another module. This caused an Exception to be thrown.


**What is the new behavior (if this is a feature change)?**

Services (and factories respectively) can now be overridden. The factory flag is cleared when replacing the service resulting in consistent behaviour in both cases: A factory would simply re-add the flag afterwards while a service won't.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Depends. If you are extremely picky, then _removing_ an error would break third-party code that somehow depended on the error being there (which admittedly *was* part of the public API)
On the other hand, this would technically mean there can never be **minor** releases because code might rely on a new method *not being present*. Hence, I would not classify this as a breaking change. All code that was working before will continue working.


**Other information**:
##### Debugging
I would have liked to trigger some WP action when an override occurs, enabling maintainers to be very defensive about this topic and throw an exception for any non-whitelisted override. That, and of course for regular debugging purposes. However, since `Package::hookName()` is inaccessible to the `ContainerConfigurator`, the only solution would be to trigger the action with a _generic_ hook name (like `inpsyde.modularity.on-service-override`), which I feel is undesired for this scenario.

##### Stability
There is a concern about introducing potential bugs due to **accidental** service overrides. These can happen if two modules (from separate sources that do not communicate with or know each other) happen to use the same service ID. This might go unnoticed by the package maintainer (especially because we currently do not have a mechanism to notify anyone about it). This is something should need to evaluate. Future development can help mitigate this if it occurs: We could...
* introduce the aforementioned WP hook to be defensive about it
* introduce an `allowOverride()` method to whitelist at `Package`level
* introduce a `CollisionResolver` interface to do the same - and then some
* inspect the list of services (and therefore potential overrides) from a composer plugin - and notify maintainers during `composer install` 

Ultimately, this **is** the package maintainers' responsibility. In a scenario where an accidental override might occur, it is _already_ possible for similar problems to stem from [extensions](https://github.com/inpsyde/modularity/blob/64049e964d894282f03b75946badfc0fca87884f/docs/Modules.md#extendingmodule)