### PR TITLE
Make sure "name" is generated for LibraryProperties

### DIFF
--- a/src/Properties/LibraryProperties.php
+++ b/src/Properties/LibraryProperties.php
@@ -79,7 +79,8 @@ class LibraryProperties extends BaseProperties
             $properties[self::PROP_VERSION] = $version;
         }
 
-        [$basePath, $baseName, $name] = static::buildNames($composerJsonData, $composerJsonFile);
+        $basePath = dirname($composerJsonFile);
+        [$baseName, $name] = static::buildNames($composerJsonData, $composerJsonFile);
         if (empty($properties[self::PROP_NAME])) {
             $properties[self::PROP_NAME] = $name;
         }
@@ -94,15 +95,11 @@ class LibraryProperties extends BaseProperties
 
     /**
      * @param array $composerJsonData
-     * @param string $composerJsonFile
      *
-     * @return array{string, string, string}
+     * @return array{string, string}
      */
-    private static function buildNames(array $composerJsonData, string $composerJsonFile): array
+    private static function buildNames(array $composerJsonData): array
     {
-        $composerName = (string) ($composerJsonData['name'] ?? '');
-        $basePath = dirname($composerJsonFile);
-
         $packageNamePieces = explode('/', $composerName, 2);
         $basename = implode('-', $packageNamePieces);
         // "inpsyde/foo-bar-baz" => "Inpsyde Foo Bar Baz"
@@ -111,7 +108,7 @@ class LibraryProperties extends BaseProperties
             MB_CASE_TITLE
         );
 
-        return [$basePath, $basename, $name];
+        return [$basename, $name];
     }
 
     /**

--- a/src/Properties/LibraryProperties.php
+++ b/src/Properties/LibraryProperties.php
@@ -79,8 +79,7 @@ class LibraryProperties extends BaseProperties
             $properties[self::PROP_VERSION] = $version;
         }
 
-        $basePath = dirname($composerJsonFile);
-        [$baseName, $name] = static::buildNames($composerJsonData, $composerJsonFile);
+        [$basePath, $baseName, $name] = static::buildNames($composerJsonData, $composerJsonFile);
         if (empty($properties[self::PROP_NAME])) {
             $properties[self::PROP_NAME] = $name;
         }
@@ -95,11 +94,15 @@ class LibraryProperties extends BaseProperties
 
     /**
      * @param array $composerJsonData
+     * @param string $composerJsonFile
      *
-     * @return array{string, string}
+     * @return array{string, string, string}
      */
-    private static function buildNames(array $composerJsonData): array
+    private static function buildNames(array $composerJsonData, string $composerJsonFile): array
     {
+        $composerName = (string) ($composerJsonData['name'] ?? '');
+        $basePath = dirname($composerJsonFile);
+
         $packageNamePieces = explode('/', $composerName, 2);
         $basename = implode('-', $packageNamePieces);
         // "inpsyde/foo-bar-baz" => "Inpsyde Foo Bar Baz"
@@ -108,7 +111,7 @@ class LibraryProperties extends BaseProperties
             MB_CASE_TITLE
         );
 
-        return [$basename, $name];
+        return [$basePath, $basename, $name];
     }
 
     /**

--- a/src/Properties/LibraryProperties.php
+++ b/src/Properties/LibraryProperties.php
@@ -79,7 +79,8 @@ class LibraryProperties extends BaseProperties
             $properties[self::PROP_VERSION] = $version;
         }
 
-        [$basePath, $baseName, $name] = static::buildNames($composerJsonData, $composerJsonFile);
+        [$baseName, $name] = static::buildNames($composerJsonData);
+        $basePath = dirname($composerJsonFile);
         if (empty($properties[self::PROP_NAME])) {
             $properties[self::PROP_NAME] = $name;
         }
@@ -94,15 +95,12 @@ class LibraryProperties extends BaseProperties
 
     /**
      * @param array $composerJsonData
-     * @param string $composerJsonFile
      *
-     * @return array{string, string, string}
+     * @return array{string, string}
      */
-    private static function buildNames(array $composerJsonData, string $composerJsonFile): array
+    private static function buildNames(array $composerJsonData): array
     {
         $composerName = (string) ($composerJsonData['name'] ?? '');
-        $basePath = dirname($composerJsonFile);
-
         $packageNamePieces = explode('/', $composerName, 2);
         $basename = implode('-', $packageNamePieces);
         // "inpsyde/foo-bar-baz" => "Inpsyde Foo Bar Baz"
@@ -111,7 +109,7 @@ class LibraryProperties extends BaseProperties
             MB_CASE_TITLE
         );
 
-        return [$basePath, $basename, $name];
+        return [$basename, $name];
     }
 
     /**

--- a/src/Properties/LibraryProperties.php
+++ b/src/Properties/LibraryProperties.php
@@ -104,10 +104,6 @@ class LibraryProperties extends BaseProperties
         $basePath = dirname($composerJsonFile);
 
         $packageNamePieces = explode('/', $composerName, 2);
-        if (empty($packageNamePieces[1])) {
-            return [$basePath, $composerName, $composerName];
-        }
-
         $basename = implode('-', $packageNamePieces);
         // "inpsyde/foo-bar-baz" => "Inpsyde Foo Bar Baz"
         $name = mb_convert_case(

--- a/src/Properties/LibraryProperties.php
+++ b/src/Properties/LibraryProperties.php
@@ -79,8 +79,10 @@ class LibraryProperties extends BaseProperties
             $properties[self::PROP_VERSION] = $version;
         }
 
-        $baseName = static::buildBaseName((string) $composerJsonData['name']);
-        $basePath = dirname($composerJsonFile);
+        [$basePath, $baseName, $name] = static::buildNames($composerJsonData, $composerJsonFile);
+        if (empty($properties[self::PROP_NAME])) {
+            $properties[self::PROP_NAME] = $name;
+        }
 
         return new self(
             $baseName,
@@ -91,15 +93,29 @@ class LibraryProperties extends BaseProperties
     }
 
     /**
-     * @param string $packageName
+     * @param array $composerJsonData
+     * @param string $composerJsonFile
      *
-     * @return string
+     * @return array{string, string, string}
      */
-    private static function buildBaseName(string $packageName): string
+    private static function buildNames(array $composerJsonData, string $composerJsonFile): array
     {
-        $packageNamePieces = explode('/', $packageName, 2);
+        $composerName = (string) ($composerJsonData['name'] ?? '');
+        $basePath = dirname($composerJsonFile);
 
-        return implode('-', $packageNamePieces);
+        $packageNamePieces = explode('/', $composerName, 2);
+        if (empty($packageNamePieces[1])) {
+            return [$basePath, $composerName, $composerName];
+        }
+
+        $basename = implode('-', $packageNamePieces);
+        // "inpsyde/foo-bar-baz" => "Inpsyde Foo Bar Baz"
+        $name = mb_convert_case(
+            str_replace(['-', '_', '.'], ' ', implode(' ', $packageNamePieces)),
+            MB_CASE_TITLE
+        );
+
+        return [$basePath, $basename, $name];
     }
 
     /**

--- a/tests/unit/Properties/LibraryPropertiesTest.php
+++ b/tests/unit/Properties/LibraryPropertiesTest.php
@@ -73,9 +73,10 @@ class LibraryPropertiesTest extends TestCase
      */
     public function testForLibraryWithoutVendor(): void
     {
-        $expectedName = "properties-test";
+        $expectedBaseName = "properties-test";
+        $expectedName = "Properties Test";
         $composerJsonData = [
-            "name" => $expectedName,
+            "name" => $expectedBaseName,
         ];
 
         $structure = [
@@ -87,7 +88,8 @@ class LibraryPropertiesTest extends TestCase
 
         $testee = LibraryProperties::new($root->url() . '/json/composer.json');
 
-        static::assertSame($expectedName, $testee->baseName());
+        static::assertSame($expectedBaseName, $testee->baseName());
+        static::assertSame($expectedName, $testee->name());
     }
 
     /**

--- a/tests/unit/Properties/LibraryPropertiesTest.php
+++ b/tests/unit/Properties/LibraryPropertiesTest.php
@@ -26,7 +26,8 @@ class LibraryPropertiesTest extends TestCase
     public function testForLibrary(): void
     {
         $inputName = 'vendor/test';
-        $expectedName = "vendor-test";
+        $expectedBaseName = "vendor-test";
+        $expectedName = "Vendor Test";
         $composerJsonData = [
             "name" => $inputName,
         ];
@@ -40,7 +41,8 @@ class LibraryPropertiesTest extends TestCase
 
         $testee = LibraryProperties::new($root->url() . '/json/composer.json');
 
-        static::assertSame($expectedName, $testee->baseName());
+        static::assertSame($expectedBaseName, $testee->baseName());
+        static::assertSame($expectedName, $testee->name());
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature.

**What is the current behavior?** (You can also link to an open issue here)

A library that does not define a `extra.modularity.name` property has an empty `LibraryProperties::name()`.

**What is the new behavior (if this is a feature change)?**

In the case a library does not define a `extra.modularity.name` property, a name is calculated based on the Composer package name.

As an example, a library with a Composer name `inpsyde/foo-bar-baz` woudl have an auto-generated name `Inpsyde Foo Bar Baz`.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:

QA is failing due to a deprecated Psalm configuration which I did not want to address in this PR being unrelated.
