### PR TITLE
Unify inpsyde.com spelling

### DIFF
--- a/docs/Package.md
+++ b/docs/Package.md
@@ -73,7 +73,7 @@ declare(strict_types=1);
 /*
  * Plugin Name:       Acme
  * Author:            Inpsyde GmbH
- * Author URI:        https://inpsyde.com
+ * Author URI:        https://inpsyde.com/
  * Version:           1.0.0
  * Text Domain:       acme
  */

--- a/tests/unit/Properties/LibraryPropertiesTest.php
+++ b/tests/unit/Properties/LibraryPropertiesTest.php
@@ -100,7 +100,7 @@ class LibraryPropertiesTest extends TestCase
         $expectedBaseName = "properties-test";
         $expectedDescription = 'the description';
         $expectedAuthor = 'Inpsyde GmbH';
-        $expectedAuthorUri = 'https://www.inpsyde.com';
+        $expectedAuthorUri = 'https://inpsyde.com/';
         $expectedDomainPath = 'languages/';
         $expectedName = "Properties Test";
         $expectedTextDomain = 'properties-test';

--- a/tests/unit/Properties/PluginPropertiesTest.php
+++ b/tests/unit/Properties/PluginPropertiesTest.php
@@ -18,7 +18,7 @@ class PluginPropertiesTest extends TestCase
     {
         $expectedDescription = 'the description';
         $expectedAuthor = 'Inpsyde GmbH';
-        $expectedAuthorUri = 'https://www.inpsyde.com';
+        $expectedAuthorUri = 'https://inpsyde.com/';
         $expectedDomainPath = 'languages/';
         $expectedName = "Properties Test";
         $expectedTextDomain = 'properties-test';
@@ -119,7 +119,7 @@ class PluginPropertiesTest extends TestCase
         $expectedBaseName = 'plugin-name';
         $expectedBasePath = '/path/to/plugin/';
         $expectedAuthor = 'Inpsyde GmbH';
-        $expectedAuthorUri = 'https://www.inpsyde.com';
+        $expectedAuthorUri = 'https://inpsyde.com/';
 
         $pluginData = array_merge(
             [

--- a/tests/unit/Properties/ThemePropertiesTest.php
+++ b/tests/unit/Properties/ThemePropertiesTest.php
@@ -19,7 +19,7 @@ class ThemePropertiesTest extends TestCase
     {
         $expectedDescription = 'the description';
         $expectedAuthor = 'Inpsyde GmbH';
-        $expectedAuthorUri = 'https://www.inpsyde.com';
+        $expectedAuthorUri = 'https://inpsyde.com/';
         $expectedDomainPath = 'languages/';
         $expectedName = "Properties Test";
         $expectedTextDomain = 'properties-test';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Chore


**What is the current behavior?** (You can also link to an open issue here)
There are different spellings of the inpsyde.com domain, e.g. `https://www.inpsyde.com`, `https://inpsyde.com` or `https://inpsyde.com/`.


**What is the new behavior (if this is a feature change)?**
The spelling of the inpsyde.com domain has been standardized to `https://inpsyde.com/`.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

**Other information**:
Related PR: https://github.com/inpsyde/generator-inpsyde/pull/319