### PR TITLE
Introduce ContainerCompiler

### DIFF
--- a/docs/PSR-11-Container.md
+++ b/docs/PSR-11-Container.md
@@ -1,15 +1,126 @@
-# Default Container based on PSR-11
-The used Container in your Application is based on PSR-11 and allows you via Modules to set, extend and get Services. The consuming Services from your Modules has read-only access to the Container. Adding new Factories to the Container will only be possible via an own Container or a Module.
+# Container
 
-The default (primary) Container is a delegating Container and receives aside from Factories, Extensions also PSR-based child Containers, which are registered via Package-class. If a Service cannot be resolved via the primary Container, it will resort to the has and get methods of the delegates to resolve the requested Service. Additionally, the primary Container will allow you not only to access Services, it will also allow you to extend Services from child Containers.
+Modularity's primary container is a [PSR-11](https://www.php-fig.org/psr/psr-11/) implementation
+that is "compiled" from the various _services_, _factories_, and _extensions_ configured by modules.
 
-You can simply register an own PSR-Container via Package like following:
+## Child Containers
+
+Besides definitions in modules, the Modularity container is capable of delegating services'
+resolution to other PSR-11 "child containers", that can be added via the `Package` class.
+
+In fact, if the container can not find a service in the primary "parent" container, it will attempt
+to resolve it delegating to "child containers".
+
+Registering an external PSR-11 container via the `Package` class looks like this:
 
 ```php
 <?php
+// a couple of examples of custom PSR-11 containers
 $leagueContainer = new League\Container\Container();
 $diContainer = new Di\Container();
 
+$module = new MyModule();
+
 Inpsyde\Modularity\Package::new($properties, $leagueContainer, $diContainer)
-    ->boot();
+    ->boot($module);
 ```
+
+In the example above, `MyModule::run()` method will receive a PSR-11 container capable of resolving
+services from both the external containers passed to `Package::new()`.
+
+In the case of name collision, the resolution is _FIFO_: the container added first will take
+precedence.
+
+Please note that if `MyModule` is an `ExtendingModule`, it will be capable of extending services
+registered by the two "external" containers.
+
+
+## Container Compiler
+
+Another way Modularity is open to extensions via PSR-11 is the "container compiler".
+
+A compiler is an object that takes _services_, _factories_, and _extensions_ added by modules, plus
+"child" containers added to it and then "compile" a PSR-11 container.
+
+This is what the Modularity's `ReadOnlyContainerCompiler` class does, and it is instantiated
+when we call `Package::new()`.
+
+However, the `Package` class provides a different static constructor that allow us to use a
+custom compiler.
+
+An example:
+
+```php
+<?php
+use Inpsyde\Modularity;
+use Psr\Container\ContainerInterface;
+
+class FilteredContainer implements ContainerInterface
+{
+    public function __construct(private ContainerInterface $container)
+    {
+    }
+
+    public function has(string $id): bool
+    {
+        return $this->container->has($id);
+    }
+            
+    public function get(string $id): mixed
+    {
+        return apply_filters("my-container-service-{$id}", $this->container->get($id));
+    }
+}
+
+class FilteredContainerCompiler extends Modularity\Container\ReadOnlyContainerCompiler
+{
+    public function compile(): ContainerInterface
+    {
+        return new FilteredContainer(parent::compile());
+    }
+}
+
+Modularity\Package::newWithCompiler($properties, new FilteredContainerCompiler())
+    ->boot(new MyModule());
+```
+
+
+### Custom compiler for services definition
+
+The main reason to exist for the custom compiler is to allow "decoration" of the default read-only
+container.
+
+That could be useful for debugging, profiling, etc.
+
+However, the custom compiler could be used for anything, including returning a container that
+has new services, or services that override what is defined in modules.
+
+In that case, **it is important the compiled container takes into account defined services, factories
+and extensions** to don't break the "contract" the package has with any module registering
+services.
+
+Moreover, please keep in mind services defined in "child" containers can be extended by modules, 
+whereas any service returned by the custom compiled container's `get()` method can not be extended 
+anymore.
+
+### About `Package::new()` VS `Package::newWithCompiler()`
+
+It is worth nothing that `Package::new()` is little less than a wrapper around 
+`Package::newWithCompiler()` where the container builder is constructed from given containers.
+
+That is:
+
+```php
+Inpsyde\Modularity\Package::new($properties, $container1, $container2);
+```
+
+is equivalent to:
+
+```php
+Inpsyde\Modularity\Package::newWithCompiler(
+    $properties,
+    new Inpsyde\Modularity\Container\ReadOnlyContainerCompiler($container1, $container2)
+);
+```
+
+

--- a/src/Container/ContainerCompiler.php
+++ b/src/Container/ContainerCompiler.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inpsyde\Modularity\Container;
+
+use Psr\Container\ContainerInterface;
+
+interface ContainerCompiler
+{
+    /**
+     * @param ContainerInterface $container
+     * @return void
+     */
+    public function addContainer(ContainerInterface $container): void;
+
+    /**
+     * @param string $id
+     * @param callable(ContainerInterface $container):mixed $factory
+     * @return void
+     */
+    public function addFactory(string $id, callable $factory): void;
+
+    /**
+     * @param string $id
+     * @param callable(ContainerInterface $container):mixed $service
+     * @return void
+     */
+    public function addService(string $id, callable $service): void;
+
+    /**
+     * @param string $id
+     * @return bool
+     */
+    public function hasService(string $id): bool;
+
+    /**
+     * @param string $id
+     * @param callable(mixed $service, ContainerInterface $container):mixed $extender
+     * @return void
+     */
+    public function addExtension(string $id, callable $extender): void;
+
+    /**
+     * @param string $id
+     * @return bool
+     */
+    public function hasExtension(string $id): bool;
+
+    /**
+     * @return ContainerInterface
+     */
+    public function compile(): ContainerInterface;
+}

--- a/src/Container/ContainerConfigurator.php
+++ b/src/Container/ContainerConfigurator.php
@@ -1,157 +1,31 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Inpsyde\Modularity\Container;
 
-use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 
-class ContainerConfigurator
+/**
+ * @deprecated Use ReadOnlyContainerCompiler instead.
+ */
+class ContainerConfigurator extends ReadOnlyContainerCompiler
 {
     /**
-     * @var array<string, callable(ContainerInterface $container):mixed>
-     */
-    private $services = [];
-
-    /**
-     * @var array<string, bool>
-     */
-    private $factoryIds = [];
-
-    /**
-     * @var array<string, array<callable(mixed $service, ContainerInterface $container):mixed>>
-     */
-    private $extensions = [];
-
-    /**
-     * @var ContainerInterface[]
-     */
-    private $containers = [];
-
-    /**
-     * @var null|ContainerInterface
-     */
-    private $compiledContainer;
-
-    /**
-     * ContainerConfigurator constructor.
-     *
-     * @param ContainerInterface[] $containers
+     * @param list<ContainerInterface> $containers
      */
     public function __construct(array $containers = [])
     {
-        array_map([$this, 'addContainer'], $containers);
+        parent::__construct(...$containers);
     }
 
     /**
-     * Allowing to add child containers.
-     *
-     * @param ContainerInterface $container
-     */
-    public function addContainer(ContainerInterface $container): void
-    {
-        $this->containers[] = $container;
-    }
-
-    /**
-     * @param string $id
-     * @param callable(ContainerInterface $container):mixed $factory
-     */
-    public function addFactory(string $id, callable $factory): void
-    {
-        $this->addService($id, $factory);
-        // We're using a hash table to detect later
-        // via isset() if a Service as a Factory.
-        $this->factoryIds[$id] = true;
-    }
-
-    /**
-     * @param string $id
-     * @param callable(ContainerInterface $container):mixed $service
-     *
-     * @return void
-     */
-    public function addService(string $id, callable $service): void
-    {
-        if ($this->hasService($id)) {
-            /*
-             * We are being intentionally permissive here,
-             * allowing a simple workflow for *intentional* overrides
-             * while accepting the (small?) risk of *accidental* overrides
-             * that could be hard to notice and debug.
-             */
-
-            /*
-             * Clear a factory flag in case it was a factory.
-             * If needs be, it will get re-added after this function completes.
-             */
-            unset($this->factoryIds[$id]);
-        }
-
-        $this->services[$id] = $service;
-    }
-
-    /**
-     * @param string $id
-     *
-     * @return bool
-     */
-    public function hasService(string $id): bool
-    {
-        if (array_key_exists($id, $this->services)) {
-            return true;
-        }
-
-        foreach ($this->containers as $container) {
-            if ($container->has($id)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @param string $id
-     * @param callable(mixed $service, ContainerInterface $container):mixed $extender
-     *
-     * @return void
-     */
-    public function addExtension(string $id, callable $extender): void
-    {
-        if (!isset($this->extensions[$id])) {
-            $this->extensions[$id] = [];
-        }
-
-        $this->extensions[$id][] = $extender;
-    }
-
-    /**
-     * @param string $id
-     *
-     * @return bool
-     */
-    public function hasExtension(string $id): bool
-    {
-        return isset($this->extensions[$id]);
-    }
-
-    /**
-     * Returns a read only version of this Container.
-     *
      * @return ContainerInterface
+     *
+     * @deprecated Use ReadOnlyContainerCompiler::compile() instead.
      */
     public function createReadOnlyContainer(): ContainerInterface
     {
-        if (!$this->compiledContainer) {
-            $this->compiledContainer = new ReadOnlyContainer(
-                $this->services,
-                $this->factoryIds,
-                $this->extensions,
-                $this->containers
-            );
-        }
-
-        return $this->compiledContainer;
+        return $this->compile();
     }
 }

--- a/src/Container/ReadOnlyContainerCompiler.php
+++ b/src/Container/ReadOnlyContainerCompiler.php
@@ -1,0 +1,144 @@
+<?php
+declare(strict_types=1);
+
+namespace Inpsyde\Modularity\Container;
+
+use Psr\Container\ContainerInterface;
+
+class ReadOnlyContainerCompiler implements ContainerCompiler
+{
+    /**
+     * @var array<string, callable(ContainerInterface $container):mixed>
+     */
+    private $services = [];
+
+    /**
+     * @var array<string, bool>
+     */
+    private $factoryIds = [];
+
+    /**
+     * @var array<string, array<callable(mixed $service, ContainerInterface $container):mixed>>
+     */
+    private $extensions = [];
+
+    /**
+     * @var ContainerInterface[]
+     */
+    private $containers = [];
+
+    /**
+     * @param ContainerInterface ...$containers
+     */
+    public function __construct(ContainerInterface ...$containers)
+    {
+        array_map([$this, 'addContainer'], $containers);
+    }
+
+    /**
+     * @param ContainerInterface $container
+     * @return void
+     */
+    public function addContainer(ContainerInterface $container): void
+    {
+        $this->containers[] = $container;
+    }
+
+    /**
+     * @param string $id
+     * @param callable(ContainerInterface $container):mixed $factory
+     */
+    public function addFactory(string $id, callable $factory): void
+    {
+        $this->addService($id, $factory);
+        // We're using a hash table to detect later
+        // via isset() if a Service as a Factory.
+        $this->factoryIds[$id] = true;
+    }
+
+    /**
+     * @param string $id
+     * @param callable(ContainerInterface $container):mixed $service
+     *
+     * @return void
+     */
+    public function addService(string $id, callable $service): void
+    {
+        if ($this->hasService($id)) {
+            /*
+             * We are being intentionally permissive here,
+             * allowing a simple workflow for *intentional* overrides
+             * while accepting the (small?) risk of *accidental* overrides
+             * that could be hard to notice and debug.
+             */
+
+            /*
+             * Clear a factory flag in case it was a factory.
+             * If needs be, it will get re-added after this function completes.
+             */
+            unset($this->factoryIds[$id]);
+        }
+
+        $this->services[$id] = $service;
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return bool
+     */
+    public function hasService(string $id): bool
+    {
+        if (array_key_exists($id, $this->services)) {
+            return true;
+        }
+
+        foreach ($this->containers as $container) {
+            if ($container->has($id)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $id
+     * @param callable(mixed $service, ContainerInterface $container):mixed $extender
+     *
+     * @return void
+     */
+    public function addExtension(string $id, callable $extender): void
+    {
+        if (!isset($this->extensions[$id])) {
+            $this->extensions[$id] = [];
+        }
+
+        $this->extensions[$id][] = $extender;
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return bool
+     */
+    public function hasExtension(string $id): bool
+    {
+        return isset($this->extensions[$id]);
+    }
+
+    /**
+     * Returns a read only version of this Container.
+     *
+     * @return ContainerInterface
+     */
+    public function compile(): ContainerInterface
+    {
+        return new ReadOnlyContainer(
+            $this->services,
+            $this->factoryIds,
+            $this->extensions,
+            $this->containers
+        );
+    }
+}

--- a/src/Package.php
+++ b/src/Package.php
@@ -140,7 +140,7 @@ class Package
      *
      * @var int
      */
-    private $status = self::STATUS_IDLE;
+    protected $status = self::STATUS_IDLE;
 
     /**
      * Contains the progress of all modules.
@@ -149,7 +149,7 @@ class Package
      *
      * @var array<string, list<string>>
      */
-    private $moduleStatus = [self::MODULES_ALL => []];
+    protected $moduleStatus = [self::MODULES_ALL => []];
 
     /**
      * Hashmap of where keys are names of connected packages, and values are boolean, true
@@ -169,12 +169,12 @@ class Package
     /**
      * @var Properties
      */
-    private $properties;
+    protected $properties;
 
     /**
      * @var ContainerCompiler
      */
-    private $containerCompiler;
+    protected $containerCompiler;
 
     /**
      * @var ContainerInterface|null
@@ -210,7 +210,7 @@ class Package
      * @param Properties $properties
      * @param ContainerCompiler $containerCompiler
      */
-    private function __construct(Properties $properties, ContainerCompiler $containerCompiler)
+    protected function __construct(Properties $properties, ContainerCompiler $containerCompiler)
     {
         $this->properties = $properties;
 

--- a/tests/unit/Container/ReadOnlyContainerCompilerTest.php
+++ b/tests/unit/Container/ReadOnlyContainerCompilerTest.php
@@ -4,23 +4,22 @@ declare(strict_types=1);
 
 namespace Inpsyde\Modularity\Tests\Unit\Container;
 
-use Inpsyde\Modularity\Container\ContainerConfigurator;
+use Inpsyde\Modularity\Container\ReadOnlyContainerCompiler;
 use Inpsyde\Modularity\Tests\TestCase;
 use Psr\Container\ContainerInterface;
 
-class ContainerConfiguratorTest extends TestCase
+class ReadOnlyContainerCompilerTest extends TestCase
 {
     /**
      * @test
      */
     public function testBasic(): void
     {
-        $testee = new ContainerConfigurator();
+        $testee = new ReadOnlyContainerCompiler();
 
-        static::assertInstanceOf(ContainerConfigurator::class, $testee);
         static::assertFalse($testee->hasService('something'));
         static::assertFalse($testee->hasExtension('something'));
-        static::assertInstanceOf(ContainerInterface::class, $testee->createReadOnlyContainer());
+        static::assertInstanceOf(ContainerInterface::class, $testee->compile());
     }
 
     /**
@@ -32,7 +31,7 @@ class ContainerConfiguratorTest extends TestCase
         $expectedValue = new class {
         };
 
-        $testee = new ContainerConfigurator();
+        $testee = new ReadOnlyContainerCompiler();
 
         static::assertFalse($testee->hasService($expectedKey));
 
@@ -55,7 +54,7 @@ class ContainerConfiguratorTest extends TestCase
         $expectedValue = new class {
         };
 
-        $testee = new ContainerConfigurator();
+        $testee = new ReadOnlyContainerCompiler();
 
         static::assertFalse($testee->hasService($expectedKey));
 
@@ -76,7 +75,7 @@ class ContainerConfiguratorTest extends TestCase
     {
         $expectedKey = 'key';
 
-        $testee = new ContainerConfigurator();
+        $testee = new ReadOnlyContainerCompiler();
         $testee->addService(
             $expectedKey,
             function () {
@@ -89,7 +88,7 @@ class ContainerConfiguratorTest extends TestCase
                 return new \DateTimeImmutable();
             }
         );
-        $container = $testee->createReadOnlyContainer();
+        $container = $testee->compile();
         $result = $container->get($expectedKey);
 
         self::assertInstanceOf(\DateTimeImmutable::class, $result);
@@ -102,7 +101,7 @@ class ContainerConfiguratorTest extends TestCase
     {
         $expectedKey = 'key';
 
-        $testee = new ContainerConfigurator();
+        $testee = new ReadOnlyContainerCompiler();
         $testee->addFactory(
             $expectedKey,
             function () {
@@ -115,7 +114,7 @@ class ContainerConfiguratorTest extends TestCase
                 return new \DateTimeImmutable();
             }
         );
-        $container = $testee->createReadOnlyContainer();
+        $container = $testee->compile();
         $result = $container->get($expectedKey);
 
         self::assertInstanceOf(\DateTimeImmutable::class, $result);
@@ -128,7 +127,7 @@ class ContainerConfiguratorTest extends TestCase
     {
         $expectedKey = 'key';
 
-        $testee = new ContainerConfigurator();
+        $testee = new ReadOnlyContainerCompiler();
         $testee->addService(
             $expectedKey,
             function () {
@@ -141,7 +140,7 @@ class ContainerConfiguratorTest extends TestCase
                 return new \DateTimeImmutable();
             }
         );
-        $container = $testee->createReadOnlyContainer();
+        $container = $testee->compile();
         $result = $container->get($expectedKey);
 
         self::assertInstanceOf(\DateTimeImmutable::class, $result);
@@ -163,7 +162,7 @@ class ContainerConfiguratorTest extends TestCase
     {
         $expectedKey = 'key';
 
-        $testee = new ContainerConfigurator();
+        $testee = new ReadOnlyContainerCompiler();
         $testee->addFactory(
             $expectedKey,
             function () {
@@ -176,7 +175,7 @@ class ContainerConfiguratorTest extends TestCase
                 return new \DateTimeImmutable();
             }
         );
-        $container = $testee->createReadOnlyContainer();
+        $container = $testee->compile();
         $result = $container->get($expectedKey);
 
         self::assertInstanceOf(\DateTimeImmutable::class, $result);
@@ -195,7 +194,7 @@ class ContainerConfiguratorTest extends TestCase
      */
     public function testHasServiceNotFound(): void
     {
-        $testee = new ContainerConfigurator();
+        $testee = new ReadOnlyContainerCompiler();
         static::assertFalse($testee->hasService('unknown-service'));
     }
 
@@ -232,8 +231,7 @@ class ContainerConfiguratorTest extends TestCase
             }
         };
 
-        $testee = new ContainerConfigurator();
-        $testee->addContainer($childContainer);
+        $testee = new ReadOnlyContainerCompiler($childContainer);
 
         static::assertTrue($testee->hasService($expectedKey));
     }
@@ -243,7 +241,7 @@ class ContainerConfiguratorTest extends TestCase
      */
     public function testAddExtension(): void
     {
-        $testee = new ContainerConfigurator();
+        $testee = new ReadOnlyContainerCompiler();
 
         $expectedKey = 'key';
         $expected = 'expectedValue';
@@ -285,7 +283,7 @@ class ContainerConfiguratorTest extends TestCase
 
         static::assertTrue($testee->hasService($expectedKey));
         static::assertTrue($testee->hasExtension($expectedKey));
-        static::assertSame($expectedExtendedValue, $testee->createReadOnlyContainer()->get($expectedKey));
+        static::assertSame($expectedExtendedValue, $testee->compile()->get($expectedKey));
     }
 
     /**
@@ -315,11 +313,11 @@ class ContainerConfiguratorTest extends TestCase
             }
         };
 
-        $testee = new ContainerConfigurator([$childContainer]);
+        $testee = new ReadOnlyContainerCompiler($childContainer);
 
         static::assertTrue($testee->hasService($expectedId));
 
-        $readOnlyContainer = $testee->createReadOnlyContainer();
+        $readOnlyContainer = $testee->compile();
         static::assertSame($expectedValue, $readOnlyContainer->get($expectedId));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature.

**What is the current behavior?** (You can also link to an open issue here)

See details below.


**What is the new behavior (if this is a feature change)?**

See details below.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

---

# The issue

Currently, Modularity uses an hardcoded depency to the `ContainerConfigurator` class to "collect" factories, services, extensions, and child containers, and then builds an instance of the  `ReadOnlyContainer` PSR-11 implementation.

While this works most of the time, it make it impossible to use different PSR-11 implementation, for example to "decorate" the given container for debugging, logging, or similar things.

# The proposed solution

The idea is to have a `ContainerCompiler` interface of which the current `ContainerConfigurator` would be one implementation (only implementation shipped with Modularity).

With an interface, consumers could provide their implementation and build a PSR-11 container as they like.

While the compiler enables very flexible operation, we believe most of the time the returned container should extend or decorate the provided `ReadOnlyContainer` to avoid breaking the package's "contract" with modules. 

# The implementation

To not break backward compatibility with the existing `Package::new()` method, we introduce a new `Package::newWithCompiler()` static constrcutor, that instead of accepting a number fo child container accepts instead a ready-made Compiler.

With such approach `Package::new($properties, $container1, $container2)` becomes equivalent to: `Package::newWithCompiler( $properties, new ReadOnlyContainerCompiler($container1, $container2))`, but consumers can use `Package::newWithCompiler()` to pass a different implementation of the new `ContainerCompiler` interface.

The default implemenation has been renamed from  `ContainerConfigurator` to `ReadOnlyContainerCompiler`, but a class with the old name (extending the one with new name) is kept for backward compatibility. It is deprecated and will be removed in next major.
 
# Use case examples

## A filtered container

Do you like filters, don't you?

```php
class FilteredContainer implements ContainerInterface
{
    public function __construct(private ContainerInterface $container)
    {
    }

    public function has(string $id): bool
    {
        return $this->container->has($id);
    }
            
    public function get(string $id): mixed
    {
        return apply_filters("my-container-service-{$id}", $this->container->get($id));
    }
}

class FilteredContainerCompiler extends ReadOnlyContainerCompiler
{
    public function compile(): ContainerInterface
    {
        return new FilteredContainer(parent::compile());
    }
}

Package::newWithCompiler($properties, new FilteredContainerCompiler());
```

## Automatic `LoggerAware` resolution

As soon as a `LoggerInterface` object is available in the container, it injects it to every `LoggerAware` class that is resolved.

```php
class LoggerAwareResolverContainer implements ContainerInterface
{
    public function __construct(private ContainerInterface $container)
    {
    }

    public function has(string $id): bool
    {
        return $this->container->has($id);
    }
            
    public function get(string $id): mixed
    {
        $object = $this->container->get($id);
        if ((!$object instanceof LoggerAwareInterface::class) || !$this->container->has(LoggerInterface::class)) {
            return $object;
        }
        $logger = $this->container->get(LoggerInterface::class);
        $object->setLogger($logger);

        return $object;
    }
}

class LoggerAwareResolverContainerCompiler extends ReadOnlyContainerCompiler
{
    public function compile(): ContainerInterface
    {
        return new LoggerAwareResolverContainer(parent::compile());
    }
}

Package::newWithCompiler($properties, new LoggerAwareResolverContainerCompiler());
```

# Other notes

Currently, the `ContainerConfigurator` holds a container instance as property, and do not re-compile the container if it is already compiled. Now that we have an interface, we can't be sure the implementation will hold a property as well, and we don't want to risk having multiple container instances, or we defeat the benefits of having a container at all.
So the property is moved to package.

The compiler is inject to the contructor and can't be changed later because it is needed right in the constructor, at least if we want to keep the `Package::new()` signature that accepts "child" containers. Otherwise we would not know where to store the child container nor the "properties" object.
Even if we changed the `Package::new()` signature making an "impactful" breaking change, the compiler would still be needed before any `addModule()` call, hence the compiler "setter" would need to be called right after construction anyway. So we decided that it just make sense to accept it in a new static constructor an that's it.

Thanks to the fact we were wise enough to use a private constructor for the `Package` class, we can implement this change in a 100% backward compatible way.

Renaming `ContainerConfigurator` had been a breaking change. We can decide to have a new major and that's it, after all we don't expect `ContainerConfigurator` to be used in many places as independent object, or we can keep that class as deprecated and extend the new class.
So far, this PR takes the latter approach, but that's not set in stone.

This PR includes unit tests and documentaion, which might be worth a read: https://github.com/inpsyde/modularity/blob/feature/container-compiler-interface/docs/PSR-11-Container.md

# Alternatives

Like the examples above shows, most of the usage of the compiler we can think of is about decorating the default `ReadOnlyContainer`. An alternative we considered si to have a `ContainerDecorator` object, configurable to package via a setter, which if provided could be used to decorate the default container, having a single method with signature `ContainerDecorator::decorate(ContainerInterface $c): ContainerInterface`.

That would be less impactful because we don't need a new constructor nor any deprecation and renaming of `ContainerConfigurator` which would stay just as is.

On the other had, it would be less flexible, and won't solve the hardcoded `ContainerConfigurator` dependency which isn't exaclty an example of good software design.

# Feedback wanted

Of course, like any other PR, this is open to **any kind of feedback**.

However, here's below a few questions that could help the conversation:

- Naming: are `ContainerCompiler` for the interface and `ReadOnlyContainerCompiler` for the implementation good names? Better alternatives?
- Do you agree in renaning current `ContainerConfigurator`? If so, do you think we should keep the class file as deprecated for a while, or we should delete it and release a major?
- What do you think of the "alternative" implementation (using `ContainerDecorator`)?
- In a scale of 0 (not helpful at all) to 5 (fundamental) how much think this PR would be helpful in projects you're working on?