### PR TITLE
Clarify parameter meaning in Package class

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -410,23 +410,23 @@ class Package
 
     /**
      * @param string $moduleId
-     * @param string $type
+     * @param string $status
      * @param list<string>|null $serviceIds
      *
      * @return  void
      */
-    private function moduleProgress(string $moduleId, string $type, ?array $serviceIds = null)
+    private function moduleProgress(string $moduleId, string $status, ?array $serviceIds = null)
     {
-        isset($this->moduleStatus[$type]) or $this->moduleStatus[$type] = [];
-        $this->moduleStatus[$type][] = $moduleId;
+        isset($this->moduleStatus[$status]) or $this->moduleStatus[$status] = [];
+        $this->moduleStatus[$status][] = $moduleId;
 
         if (!$serviceIds || !$this->properties->isDebug()) {
-            $this->moduleStatus[self::MODULES_ALL][] = "{$moduleId} {$type}";
+            $this->moduleStatus[self::MODULES_ALL][] = "{$moduleId} {$status}";
 
             return;
         }
 
-        $description = sprintf('%s %s (%s)', $moduleId, $type, implode(', ', $serviceIds));
+        $description = sprintf('%s %s (%s)', $moduleId, $status, implode(', ', $serviceIds));
         $this->moduleStatus[self::MODULES_ALL][] = $description;
     }
 


### PR DESCRIPTION
The `moduleProgress` get passed a Module status as second parameter but the name of the parameter is `type` while the rest of the class associate the `status` meaning to it.

More over the `modulesStatus` dictionary it is holding the module Ids by statuses keys.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improve communication by giving the correct name to method parameters.
It basically renames the `$type` variable to `$status` because the parameter is referring to the Module Status.

**What is the current behavior?** (You can also link to an open issue here)
Incorrect naming for `Package::moduleProgress` parameter


**What is the new behavior (if this is a feature change)?**
Correct naming for `Package::moduleProgress` parameter

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


**Other information**:
