### PR TITLE
Add support for PSR-11 v2, and abandon 1.0

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -1,45 +1,23 @@
-name: PHP-QA
+name: Quality assurance PHP
 
-on: [ push ]
+on: ['pull_requests', 'push', 'workflow_dispatch']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint-php:
     uses: inpsyde/reusable-workflows/.github/workflows/lint-php.yml@main
     with:
-      PHP_MATRIX: >-
-        ["7.4", "8.0", "8.1", "8.2"]
+      PHP_MATRIX: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]'
+
   coding-standards-analysis-php:
     needs: lint-php
     uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@main
     with:
       PHPCS_ARGS: '--report=summary'
-  static-code-analysis-php:
+
+  static-analysis-php:
     needs: lint-php
     uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-php.yml@main
-  tests-unit-php:
-    needs: [ coding-standards-analysis-php, static-code-analysis-php ]
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
-    strategy:
-      matrix:
-        php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
-    steps:
-      - uses: actions/checkout@v1
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-versions }}
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest -a
-
-      - name: Run unit tests
-        run: composer tests:codecov
-
-      - uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
-          flags: unittests
-          verbose: true

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -1,0 +1,62 @@
+name: PHP unit tests
+
+on: ['pull_requests', 'push', 'workflow_dispatch']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests-unit-php:
+    runs-on: ubuntu-latest
+
+    env:
+      USE_COVERAGE: 'no'
+
+    strategy:
+      matrix:
+        php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        dependency-versions: [ 'lowest', 'highest' ]
+        container-versions: [ '^1', '^2' ]
+        exclude:
+          - php-versions: '7.2'
+            container-version: '^1'
+          - php-versions: '7.3'
+            container-version: '^1'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Use coverage?
+        if: ${{ (matrix.php-versions == '8.0') && (matrix.dependency-versions == 'highest') }}
+        run: echo "USE_COVERAGE=yes" >> $GITHUB_ENV
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
+          coverage: ${{ ((env.USE_COVERAGE == 'yes') && 'xdebug') || 'none' }}
+
+      - name: Setup dependencies for PSR-11 target version
+        run: |
+          composer remove brain/monkey inpsyde/php-coding-standards inpsyde/wp-stubs-versions mikey179/vfsstream vimeo/psalm --dev --no-install
+          composer require "psr/container:${{ matrix.container-versions }}" --no-install
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
+        with:
+          dependency-versions: ${{ matrix.dependency-versions }}
+
+      - name: Run unit tests
+        run: composer tests:${{ ((env.USE_COVERAGE == 'yes') && 'codecov') || 'no-cov' }}
+
+      - name: Update coverage
+        if: ${{ env.USE_COVERAGE == 'yes' }}
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: unittests
+          verbose: true

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
-        "psr/container": "^1.1.2 || ^2"
+        "psr/container": "^1.1.0 || ^2"
     },
     "require-dev": {
         "brain/monkey": "^2.6.1",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
-        "psr/container": "~1.0"
+        "psr/container": "^1.1.2 || ^2"
     },
     "require-dev": {
         "brain/monkey": "^2.6.1",

--- a/src/Container/PackageProxyContainer.php
+++ b/src/Container/PackageProxyContainer.php
@@ -34,7 +34,7 @@ class PackageProxyContainer implements ContainerInterface
      *
      * @throws \Exception
      */
-    public function get($id)
+    public function get(string $id)
     {
         assert(is_string($id));
         $this->assertPackageBooted($id);
@@ -48,7 +48,7 @@ class PackageProxyContainer implements ContainerInterface
      *
      * @throws \Exception
      */
-    public function has($id)
+    public function has(string $id): bool
     {
         assert(is_string($id));
 

--- a/src/Container/ReadOnlyContainer.php
+++ b/src/Container/ReadOnlyContainer.php
@@ -61,10 +61,8 @@ class ReadOnlyContainer implements ContainerInterface
      *
      * @return mixed
      */
-    public function get($id)
+    public function get(string $id)
     {
-        assert(is_string($id));
-
         if (array_key_exists($id, $this->resolvedServices)) {
             return $this->resolvedServices[$id];
         }
@@ -100,10 +98,8 @@ class ReadOnlyContainer implements ContainerInterface
      *
      * @return bool
      */
-    public function has($id)
+    public function has(string $id): bool
     {
-        assert(is_string($id));
-
         if (array_key_exists($id, $this->services)) {
             return true;
         }

--- a/tests/unit/Container/ContainerConfiguratorTest.php
+++ b/tests/unit/Container/ContainerConfiguratorTest.php
@@ -217,7 +217,7 @@ class ContainerConfiguratorTest extends TestCase
                 };
             }
 
-            public function get($id)
+            public function get(string $id)
             {
                 if (!$this->has($id)) {
                     return null;
@@ -226,7 +226,7 @@ class ContainerConfiguratorTest extends TestCase
                 return $this->data[$id]();
             }
 
-            public function has($id)
+            public function has(string $id): bool
             {
                 return array_key_exists($id, $this->data);
             }
@@ -304,12 +304,12 @@ class ContainerConfiguratorTest extends TestCase
                 $this->values[$expectedId] = $expectedValue;
             }
 
-            public function get($id)
+            public function get(string $id)
             {
                 return $this->values[$id];
             }
 
-            public function has($id)
+            public function has(string $id): bool
             {
                 return isset($this->values[$id]);
             }

--- a/tests/unit/Container/ReadOnlyContainerTest.php
+++ b/tests/unit/Container/ReadOnlyContainerTest.php
@@ -94,12 +94,12 @@ class ReadOnlyContainerTest extends TestCase
                 $this->data[$key] = $value;
             }
 
-            public function get($id)
+            public function get(string $id)
             {
                 return $this->data[$id];
             }
 
-            public function has($id)
+            public function has(string $id): bool
             {
                 return isset($this->data[$id]);
             }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix.

**What is the current behavior?** (You can also link to an open issue here)

Depending on the dependencies graph, type error might occur.

See #24 

**What is the new behavior (if this is a feature change)?**

--

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:

The PR contains two commits.

In the first commit, I fix the issue:
- update `composer.json`
- add type declaration in all containers (3 of which are in tests)

In the second, I extended the unit tests workflow matrix to include all possible combinations of PHP and PSR-11 versions.
Because that means a lot of combinations, I wanted to optimize the speed, so I removed X-Debug from all the combinations but one, where we generate coverage for tests.
Because that created a pretty complex workflow, I placed it in a separate workflow file for readability.

Unfortunately, on the master branch, the action workflow is not enabled for pull requests, so we can only see the check run _after_ the merge. This PR will also fix that inconvenient, so next time we can run the actions on PRs.
