### PR TITLE
Fix child theme base path property

### DIFF
--- a/src/Properties/ThemeProperties.php
+++ b/src/Properties/ThemeProperties.php
@@ -72,7 +72,7 @@ class ThemeProperties extends BaseProperties
         }
 
         $baseName = $theme->get_stylesheet();
-        $basePath = $theme->get_template_directory();
+        $basePath = $theme->get_stylesheet_directory();
         $baseUrl = (string) trailingslashit($theme->get_stylesheet_directory_uri());
 
         parent::__construct(

--- a/tests/unit/Properties/ThemePropertiesTest.php
+++ b/tests/unit/Properties/ThemePropertiesTest.php
@@ -56,7 +56,7 @@ class ThemePropertiesTest extends TestCase
             $themeStub->expects('get')->with($key)->andReturn($return);
         }
         $themeStub->expects('get_stylesheet')->andReturn($expectedBaseName);
-        $themeStub->expects('get_template_directory')->andReturn($expectedBasePath);
+        $themeStub->expects('get_stylesheet_directory')->andReturn($expectedBasePath);
         $themeStub->expects('get_stylesheet_directory_uri')->andReturn($expectedBaseUrl);
 
         Functions\expect('wp_get_theme')->with($expectedBasePath)->andReturn($themeStub);
@@ -109,7 +109,7 @@ class ThemePropertiesTest extends TestCase
         $themeStub->shouldReceive('get')->zeroOrMoreTimes()->andReturnArg(0);
 
         $themeStub->expects('get_stylesheet')->andReturn($expectedBaseName);
-        $themeStub->expects('get_template_directory')->andReturn($expectedBasePath);
+        $themeStub->expects('get_stylesheet_directory')->andReturn($expectedBasePath);
         $themeStub->expects('get_stylesheet_directory_uri')->andReturn($expectedBaseUrl);
 
         Functions\expect('wp_get_theme')->with($expectedBasePath)->andReturn($themeStub);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


**What is the current behavior?** (You can also link to an open issue here)
When using a child theme `ThemeProperties::basePath()` returns the parent theme's path. More information available in #26 


**What is the new behavior (if this is a feature change)?**
Use `get_stylesheet_directory()` instead of `get_template_directory()` for retrieving the base path of the proper theme.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
More information regarding the function usage and the difference for when having child themes available [here](https://developer.wordpress.org/reference/functions/get_stylesheet_directory/#:~:text=In%20the%20event%20a%20child%20theme%20is%20being%20used%2C%20that%20is%20the%20directory%20that%20will%20be%20returned%2C%20not%20the%20parent%20theme%20directory%20(use%20get_template_directory()%20instead%20if%20you%20want%20the%20parent%20directory).)