### PR TITLE
Add PluginProperties::pluginMainFile method

### DIFF
--- a/docs/Properties.md
+++ b/docs/Properties.md
@@ -71,6 +71,7 @@ $properties = Properties\PluginProperties::new('/path/to/plugin-main-file.php');
 
 Additionally, PluginProperties will have the following public API:
 
+- `PluginProperties::pluginMainFile(): string` - returns the Plugin main file.
 - `PluginProperties::network(): bool` - returns if the Plugin is only network-wide usable.
 - `PluginProperties::isActive(): bool` - returns if the current Plugin is active.
 - `PluginProperties::isNetworkActive(): bool` - returns if the current Plugin is network-wide active.

--- a/src/Properties/PluginProperties.php
+++ b/src/Properties/PluginProperties.php
@@ -42,7 +42,7 @@ class PluginProperties extends BaseProperties
     /**
      * @var string
      */
-    private $pluginFile;
+    private $pluginMainFile;
 
     /**
      * @var bool|null
@@ -90,7 +90,7 @@ class PluginProperties extends BaseProperties
         }
         $properties = array_merge($properties, $pluginData);
 
-        $this->pluginFile = $pluginMainFile;
+        $this->pluginMainFile = wp_normalize_path($pluginMainFile);
 
         $baseName = plugin_basename($pluginMainFile);
         $basePath = plugin_dir_path($pluginMainFile);
@@ -102,6 +102,14 @@ class PluginProperties extends BaseProperties
             $baseUrl,
             $properties
         );
+    }
+
+    /**
+     * @return string
+     */
+    public function pluginMainFile(): string
+    {
+        return $this->pluginMainFile;
     }
 
     /**
@@ -123,7 +131,7 @@ class PluginProperties extends BaseProperties
             if (!function_exists('is_plugin_active')) {
                 require_once ABSPATH . 'wp-admin/includes/plugin.php';
             }
-            $this->isActive = is_plugin_active($this->pluginFile);
+            $this->isActive = is_plugin_active($this->pluginMainFile);
         }
 
         return $this->isActive;
@@ -138,7 +146,7 @@ class PluginProperties extends BaseProperties
             if (!function_exists('is_plugin_active_for_network')) {
                 require_once ABSPATH . 'wp-admin/includes/plugin.php';
             }
-            $this->isNetworkActive = is_plugin_active_for_network($this->pluginFile);
+            $this->isNetworkActive = is_plugin_active_for_network($this->pluginMainFile);
         }
 
         return $this->isNetworkActive;
@@ -155,7 +163,7 @@ class PluginProperties extends BaseProperties
              * @psalm-suppress MixedArgument
              */
             $muPluginDir = wp_normalize_path(WPMU_PLUGIN_DIR);
-            $this->isMu = strpos($this->pluginFile, $muPluginDir) === 0;
+            $this->isMu = strpos($this->pluginMainFile, $muPluginDir) === 0;
         }
 
         return $this->isMu;

--- a/tests/unit/Properties/BasePropertiesTest.php
+++ b/tests/unit/Properties/BasePropertiesTest.php
@@ -43,6 +43,29 @@ class BasePropertiesTest extends TestCase
         static::assertSame(null, $testee->requiresWp());
     }
 
+    /**
+     * @dataProvider baseNameDataProvider
+     */
+    public function testBaseNameSanitization(string $baseName, string $sanitizedBaseName): void
+    {
+        $testee = $this->createBaseProperties(
+            $baseName,
+            ''
+        );
+
+        static::assertSame($sanitizedBaseName, $testee->baseName());
+    }
+
+    public function baseNameDataProvider(): iterable
+    {
+        yield 'empty' => ['', ''];
+        yield 'word' => ['foo', 'foo'];
+        yield 'words' => ['foo bar', 'foo bar'];
+        yield 'relative path to package' => ['path/package-dir/package.php', 'package-dir'];
+        yield 'absolute path' => ['/abs/path/package-dir/package.php', 'package-dir'];
+        yield 'single file' => ['package.php', 'package'];
+    }
+
     private function createBaseProperties(
         string $baseName,
         string $basePath,

--- a/tests/unit/Properties/PluginPropertiesTest.php
+++ b/tests/unit/Properties/PluginPropertiesTest.php
@@ -25,11 +25,13 @@ class PluginPropertiesTest extends TestCase
         $expectedUri = 'http://github.com/inpsyde/modularity';
         $expectedVersion = '1.0';
         $expectedPhpVersion = "7.4";
-        $expecteWpVersion = "5.3";
+        $expectedWpVersion = "5.3";
         $expectedNetwork = true;
 
-        $expectedBaseName = 'plugin-name';
-        $expectedBasePath = '/path/to/plugin/';
+        $expectedPluginMainFile = '/app/wp-content/plugins/plugin-dir/plugin-name.php';
+        $expectedBaseName = 'plugin-dir/plugin-name.php';
+        $expectedBasePath = '/app/wp-content/plugins/plugin-dir/';
+        $expectedSanitizedBaseName = 'plugin-dir';
 
         Functions\expect('get_plugin_data')
             ->andReturn(
@@ -42,17 +44,18 @@ class PluginPropertiesTest extends TestCase
                     'TextDomain' => $expectedTextDomain,
                     'PluginURI' => $expectedUri,
                     'Version' => $expectedVersion,
-                    'RequiresWP' => $expecteWpVersion,
+                    'RequiresWP' => $expectedWpVersion,
                     'RequiresPHP' => $expectedPhpVersion,
                     'Network' => $expectedNetwork,
                 ]
             );
 
         Functions\when('plugins_url')->returnArg(1);
+        Functions\when('wp_normalize_path')->returnArg(1);
         Functions\expect('plugin_basename')->andReturn($expectedBaseName);
         Functions\expect('plugin_dir_path')->andReturn($expectedBasePath);
 
-        $testee = PluginProperties::new($expectedBasePath);
+        $testee = PluginProperties::new($expectedPluginMainFile);
 
         static::assertInstanceOf(Properties::class, $testee);
         static::assertSame($expectedDescription, $testee->description());
@@ -63,10 +66,12 @@ class PluginPropertiesTest extends TestCase
         static::assertSame($expectedTextDomain, $testee->textDomain());
         static::assertSame($expectedUri, $testee->uri());
         static::assertSame($expectedVersion, $testee->version());
-        static::assertSame($expecteWpVersion, $testee->requiresWp());
+        static::assertSame($expectedWpVersion, $testee->requiresWp());
         static::assertSame($expectedPhpVersion, $testee->requiresPhp());
+        static::assertSame($expectedSanitizedBaseName, $testee->baseName());
         // Custom to Plugins
         static::assertSame($expectedNetwork, $testee->network());
+        static::assertSame($expectedPluginMainFile, $testee->pluginMainFile());
     }
 
     /**
@@ -74,15 +79,17 @@ class PluginPropertiesTest extends TestCase
      */
     public function testIsActive(): void
     {
-        $expectedBaseName = 'plugin-name';
-        $expectedBasePath = '/path/to/plugin/';
+        $pluginMainFile = '/app/wp-content/plugins/plugin-dir/plugin-name.php';
+        $expectedBaseName = 'plugin-dir/plugin-name.php';
+        $expectedBasePath = '/app/wp-content/plugins/plugin-dir/';
 
         Functions\when('get_plugin_data')->justReturn([]);
         Functions\when('plugins_url')->returnArg(1);
+        Functions\when('wp_normalize_path')->returnArg(1);
         Functions\expect('plugin_basename')->andReturn($expectedBaseName);
         Functions\expect('plugin_dir_path')->andReturn($expectedBasePath);
 
-        $testee = PluginProperties::new($expectedBasePath);
+        $testee = PluginProperties::new($pluginMainFile);
 
         Functions\expect('is_plugin_active')->andReturn(true);
 
@@ -94,17 +101,19 @@ class PluginPropertiesTest extends TestCase
      */
     public function testIsNetworkActive(): void
     {
-        $expectedBaseName = 'plugin-name';
-        $expectedBasePath = '/path/to/plugin/';
+        $pluginMainFile = '/app/wp-content/plugins/plugin-dir/plugin-name.php';
+        $expectedBaseName = 'plugin-dir/plugin-name.php';
+        $expectedBasePath = '/app/wp-content/plugins/plugin-dir/';
 
         Functions\expect('get_plugin_data')->andReturn([]);
         Functions\when('plugins_url')->returnArg(1);
+        Functions\when('wp_normalize_path')->returnArg(1);
         Functions\expect('plugin_basename')->andReturn($expectedBaseName);
         Functions\expect('plugin_dir_path')->andReturn($expectedBasePath);
 
         Functions\expect('is_plugin_active_for_network')->andReturn(true);
 
-        $testee = PluginProperties::new($expectedBasePath);
+        $testee = PluginProperties::new($pluginMainFile);
         static::assertTrue($testee->isNetworkActive());
     }
 
@@ -116,8 +125,11 @@ class PluginPropertiesTest extends TestCase
      */
     public function testCustomPluginHeaders(array $customHeaders): void
     {
-        $expectedBaseName = 'plugin-name';
-        $expectedBasePath = '/path/to/plugin/';
+        $pluginMainFile = '/app/wp-content/plugins/plugin-dir/plugin-name.php';
+        $expectedBaseName = 'plugin-dir/plugin-name.php';
+        $expectedBasePath = '/app/wp-content/plugins/plugin-dir/';
+        $expectedSanitizedBaseName = 'plugin-dir';
+
         $expectedAuthor = 'Inpsyde GmbH';
         $expectedAuthorUri = 'https://inpsyde.com/';
 
@@ -132,13 +144,14 @@ class PluginPropertiesTest extends TestCase
 
         Functions\expect('get_plugin_data')->andReturn($pluginData);
         Functions\when('plugins_url')->returnArg(1);
+        Functions\when('wp_normalize_path')->returnArg(1);
         Functions\expect('plugin_basename')->andReturn($expectedBaseName);
         Functions\expect('plugin_dir_path')->andReturn($expectedBasePath);
 
-        $testee = PluginProperties::new($expectedBasePath);
+        $testee = PluginProperties::new($pluginMainFile);
 
         // Check if PluginProperties do behave as normal
-        static::assertSame($expectedBaseName, $testee->baseName());
+        static::assertSame($expectedSanitizedBaseName, $testee->baseName());
         static::assertSame($expectedBasePath, $testee->basePath());
 
         // Test default Headers
@@ -192,20 +205,20 @@ class PluginPropertiesTest extends TestCase
      *
      * @dataProvider provideIsMuPluginData
      */
-    public function testIsMuPlugin(string $pluginPath, string $muPluginDir, bool $expected): void
+    public function testIsMuPlugin(string $pluginMainFile, string $muPluginDir, bool $expected): void
     {
-        $expectedBaseName = 'plugin-name';
+        $expectedBaseName = 'the-plugin/index.php';
 
         Functions\expect('get_plugin_data')->andReturn([]);
         Functions\when('plugins_url')->returnArg(1);
         Functions\expect('plugin_basename')->andReturn($expectedBaseName);
-        Functions\expect('plugin_dir_path')->andReturn($pluginPath);
+        Functions\when('plugin_dir_path')->returnArg(1);
 
         Functions\expect('wp_normalize_path')->andReturnFirstArg();
 
         define('WPMU_PLUGIN_DIR', $muPluginDir);
 
-        $testee = PluginProperties::new($pluginPath);
+        $testee = PluginProperties::new($pluginMainFile);
         static::assertSame($expected, $testee->isMuPlugin());
     }
 
@@ -216,12 +229,12 @@ class PluginPropertiesTest extends TestCase
     {
         return [
             'is not mu-plugin' => [
-                '/wp-content/plugins/the-plugin/',
+                '/wp-content/plugins/the-plugin/index.php',
                 '/wp-content/mu-plugins/',
                 false,
             ],
             'is mu-plugin' => [
-                '/wp-content/mu-plugins/the-plugin/',
+                '/wp-content/mu-plugins/the-plugin/index.php',
                 '/wp-content/mu-plugins/',
                 true,
             ],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature.


**What is the current behavior?** (You can also link to an open issue here)
There is no ability to retrieve the plugin's main file from `PluginProperties`. Such functionality could be useful for registration activation/deactivation hooks, etc.


**What is the new behavior (if this is a feature change)?**
Add the `PluginProperties::mainPluginFile` getter.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.



**Other information**:
Missed tests targeted to the `BaseProperties::sanitizeBaseName` method were added.
PluginProperties tests were updated to be more self-explanatory. 
