### PR TITLE
Fix plugin active state detection

### DIFF
--- a/src/Properties/PluginProperties.php
+++ b/src/Properties/PluginProperties.php
@@ -45,6 +45,11 @@ class PluginProperties extends BaseProperties
     private $pluginMainFile;
 
     /**
+     * @var string
+     */
+    private $pluginBaseName;
+
+    /**
      * @var bool|null
      */
     protected $isMu;
@@ -92,12 +97,12 @@ class PluginProperties extends BaseProperties
 
         $this->pluginMainFile = wp_normalize_path($pluginMainFile);
 
-        $baseName = plugin_basename($pluginMainFile);
+        $this->pluginBaseName = plugin_basename($pluginMainFile);
         $basePath = plugin_dir_path($pluginMainFile);
         $baseUrl = plugins_url('/', $pluginMainFile);
 
         parent::__construct(
-            $baseName,
+            $this->pluginBaseName,
             $basePath,
             $baseUrl,
             $properties
@@ -131,7 +136,7 @@ class PluginProperties extends BaseProperties
             if (!function_exists('is_plugin_active')) {
                 require_once ABSPATH . 'wp-admin/includes/plugin.php';
             }
-            $this->isActive = is_plugin_active($this->pluginMainFile);
+            $this->isActive = is_plugin_active($this->pluginBaseName);
         }
 
         return $this->isActive;
@@ -146,7 +151,7 @@ class PluginProperties extends BaseProperties
             if (!function_exists('is_plugin_active_for_network')) {
                 require_once ABSPATH . 'wp-admin/includes/plugin.php';
             }
-            $this->isNetworkActive = is_plugin_active_for_network($this->pluginMainFile);
+            $this->isNetworkActive = is_plugin_active_for_network($this->pluginBaseName);
         }
 
         return $this->isNetworkActive;

--- a/tests/unit/Properties/PluginPropertiesTest.php
+++ b/tests/unit/Properties/PluginPropertiesTest.php
@@ -91,7 +91,10 @@ class PluginPropertiesTest extends TestCase
 
         $testee = PluginProperties::new($pluginMainFile);
 
-        Functions\expect('is_plugin_active')->andReturn(true);
+        Functions\expect('is_plugin_active')
+            ->andReturnUsing(static function (string $baseName) use ($expectedBaseName): bool {
+                return $baseName === $expectedBaseName;
+            });
 
         static::assertTrue($testee->isActive());
     }
@@ -111,7 +114,10 @@ class PluginPropertiesTest extends TestCase
         Functions\expect('plugin_basename')->andReturn($expectedBaseName);
         Functions\expect('plugin_dir_path')->andReturn($expectedBasePath);
 
-        Functions\expect('is_plugin_active_for_network')->andReturn(true);
+        Functions\expect('is_plugin_active_for_network')
+            ->andReturnUsing(static function (string $baseName) use ($expectedBaseName): bool {
+                return $baseName === $expectedBaseName;
+            });
 
         $testee = PluginProperties::new($pluginMainFile);
         static::assertTrue($testee->isNetworkActive());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


**What is the current behavior?** (You can also link to an open issue here)
The `\Inpsyde\Modularity\Properties\PluginProperties::isActive` and `\Inpsyde\Modularity\Properties\PluginProperties::isNetworkActive` methods don't work as expected because their arguments should be the path to the plugin file relative to the plugins directory (not absolute path).


**What is the new behavior (if this is a feature change)?**
New private property `pluginBaseName` was introduced to use with `is_plugin_active` and `is_plugin_active_for_network` WordPress functions.
I don't know do we need the getter for the property.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.



**Other information**:
I targeted my previous PR because it's partially related. But it could be separated if needed.
