### PR TITLE
Exceptions

### DIFF
--- a/src/Container/PackageProxyContainer.php
+++ b/src/Container/PackageProxyContainer.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Inpsyde\Modularity\Container;
 
 use Inpsyde\Modularity\Package;
-use Psr\Container\ContainerExceptionInterface;
+use Inpsyde\Modularity\Exception\ContainerException;
+use Inpsyde\Modularity\Exception\NotFoundException;
 use Psr\Container\ContainerInterface;
 
 class PackageProxyContainer implements ContainerInterface
@@ -32,7 +33,7 @@ class PackageProxyContainer implements ContainerInterface
      * @param string $id
      * @return mixed
      *
-     * @throws \Exception
+     * @throws ContainerException | NotFoundException
      */
     public function get(string $id)
     {
@@ -46,7 +47,7 @@ class PackageProxyContainer implements ContainerInterface
      * @param string $id
      * @return bool
      *
-     * @throws \Exception
+     * @throws ContainerException
      */
     public function has(string $id): bool
     {
@@ -58,7 +59,7 @@ class PackageProxyContainer implements ContainerInterface
     /**
      * @return bool
      *
-     * @throws \Exception
+     * @throws ContainerException
      * @psalm-assert-if-true ContainerInterface $this->container
      */
     private function tryContainer(): bool
@@ -78,7 +79,7 @@ class PackageProxyContainer implements ContainerInterface
      * @param string $id
      * @return void
      *
-     * @throws \Exception
+     * @throws ContainerException
      *
      * @psalm-assert ContainerInterface $this->container
      */
@@ -93,9 +94,6 @@ class PackageProxyContainer implements ContainerInterface
             ? 'failed booting'
             : 'is not booted yet';
 
-        throw new class ("Error retrieving service {$id} because package {$name} {$status}.")
-            extends \Exception
-            implements ContainerExceptionInterface {
-        };
+        throw new ContainerException("Error retrieving service {$id} because package {$name} {$status}.");
     }
 }

--- a/src/Container/ReadOnlyContainer.php
+++ b/src/Container/ReadOnlyContainer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Inpsyde\Modularity\Container;
 
 use Psr\Container\ContainerInterface;
-use Psr\Container\NotFoundExceptionInterface;
+use Inpsyde\Modularity\Exception\NotFoundException;
 
 class ReadOnlyContainer implements ContainerInterface
 {
@@ -58,7 +58,7 @@ class ReadOnlyContainer implements ContainerInterface
 
     /**
      * @param string $id
-     *
+     * @throws NotFoundException
      * @return mixed
      */
     public function get(string $id)
@@ -87,10 +87,7 @@ class ReadOnlyContainer implements ContainerInterface
             }
         }
 
-        throw new class ("Service with ID {$id} not found.")
-            extends \Exception
-            implements NotFoundExceptionInterface {
-        };
+        throw new NotFoundException("Service with ID {$id} not found.");
     }
 
     /**

--- a/src/Exception/ContainerException.php
+++ b/src/Exception/ContainerException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Inpsyde\Modularity\Exception;
+
+use Exception;
+use Psr\Container\ContainerExceptionInterface;
+
+class ContainerException extends Exception implements ContainerExceptionInterface
+{
+}

--- a/src/Exception/FileNotFoundException.php
+++ b/src/Exception/FileNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Inpsyde\Modularity\Exception;
+
+use Exception;
+
+class FileNotFoundException extends Exception
+{
+}

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Inpsyde\Modularity\Exception;
+
+use Exception;
+use Psr\Container\NotFoundExceptionInterface;
+
+class NotFoundException extends Exception implements NotFoundExceptionInterface
+{
+}

--- a/src/Exception/StatusException.php
+++ b/src/Exception/StatusException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Inpsyde\Modularity\Exception;
+
+use Exception;
+
+class StatusException extends Exception
+{
+}

--- a/src/Package.php
+++ b/src/Package.php
@@ -12,6 +12,7 @@ use Inpsyde\Modularity\Module\FactoryModule;
 use Inpsyde\Modularity\Module\Module;
 use Inpsyde\Modularity\Module\ServiceModule;
 use Inpsyde\Modularity\Properties\Properties;
+use Inpsyde\Modularity\Exception\StatusException;
 use Psr\Container\ContainerInterface;
 
 class Package
@@ -543,13 +544,13 @@ class Package
      * @param string $action
      * @param string $operator
      *
-     * @throws \Exception
+     * @throws StatusException
      * @psalm-suppress ArgumentTypeCoercion
      */
     private function assertStatus(int $status, string $action, string $operator = '=='): void
     {
         if (!version_compare((string) $this->status, (string) $status, $operator)) {
-            throw new \Exception(sprintf("Can't %s at this point of application.", $action));
+            throw new StatusException("Can't $action at this point of application.");
         }
     }
 }

--- a/src/Properties/LibraryProperties.php
+++ b/src/Properties/LibraryProperties.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Inpsyde\Modularity\Properties;
 
+use Inpsyde\Modularity\Exception\FileNotFoundException;
+
 /**
  * Class LibraryProperties
  *
@@ -31,13 +33,13 @@ class LibraryProperties extends BaseProperties
      *
      * @return LibraryProperties
      *
-     * @throws \Exception
+     * @throws FileNotFoundException
      * @psalm-suppress MixedArrayAccess
      */
     public static function new(string $composerJsonFile, ?string $baseUrl = null): LibraryProperties
     {
         if (!\is_file($composerJsonFile) || !\is_readable($composerJsonFile)) {
-            throw new \Exception("File {$composerJsonFile} does not exist or is not readable.");
+            throw new FileNotFoundException("File {$composerJsonFile} does not exist or is not readable.");
         }
 
         $content = (string) file_get_contents($composerJsonFile);

--- a/tests/unit/Container/ReadOnlyContainerTest.php
+++ b/tests/unit/Container/ReadOnlyContainerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Inpsyde\Modularity\Tests\Unit\Container;
 
 use Inpsyde\Modularity\Container\ReadOnlyContainer as Container;
+use Inpsyde\Modularity\Exception\NotFoundException;
 use Inpsyde\Modularity\Tests\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -26,7 +27,7 @@ class ReadOnlyContainerTest extends TestCase
      */
     public function testGetUnknown(): void
     {
-        static::expectException(\Exception::class);
+        static::expectException(NotFoundException::class);
 
         $testee = $this->createContainer();
         $testee->get('unknown');

--- a/tests/unit/Properties/LibraryPropertiesTest.php
+++ b/tests/unit/Properties/LibraryPropertiesTest.php
@@ -6,6 +6,7 @@ namespace Inpsyde\Modularity\Tests\Unit\Properties;
 
 use Inpsyde\Modularity\Properties\Properties;
 use Inpsyde\Modularity\Properties\LibraryProperties;
+use Inpsyde\Modularity\Exception\FileNotFoundException;
 use Inpsyde\Modularity\Tests\TestCase;
 use org\bovigo\vfs\vfsStream;
 
@@ -16,7 +17,7 @@ class LibraryPropertiesTest extends TestCase
      */
     public function testForLibraryInvalidFile(): void
     {
-        static::expectException(\Exception::class);
+        static::expectException(FileNotFoundException::class);
         LibraryProperties::new('non-existing.file');
     }
 


### PR DESCRIPTION
Instead of using \Exception for everything we'd like to distinguish different exceptions by name.

Not only it better matches the PSR-11 being implemented in subject, but also it improves the code testability. Instead of parsing the exception message we can better control the exception class.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It improves the exception handling by introducing the named exceptions and improving the tests.

**What is the current behavior?** (You can also link to an open issue here)

Currently \Exception class is used everywhere. Instead we want to use named exception.

**What is the new behavior (if this is a feature change)?**

Code structure and tests quality improved.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:
