### PR TITLE
Remove unnecessary and expensive hasService check

### DIFF
--- a/src/Container/ContainerConfigurator.php
+++ b/src/Container/ContainerConfigurator.php
@@ -73,20 +73,16 @@ class ContainerConfigurator
      */
     public function addService(string $id, callable $service): void
     {
-        if ($this->hasService($id)) {
-            /*
-             * We are being intentionally permissive here,
-             * allowing a simple workflow for *intentional* overrides
-             * while accepting the (small?) risk of *accidental* overrides
-             * that could be hard to notice and debug.
-             */
-
-            /*
-             * Clear a factory flag in case it was a factory.
-             * If needs be, it will get re-added after this function completes.
-             */
-            unset($this->factoryIds[$id]);
-        }
+        /*
+         * We are being intentionally permissive here,
+         * allowing a simple workflow for *intentional* overrides
+         * while accepting the (small?) risk of *accidental* overrides
+         * that could be hard to notice and debug.
+         *
+         * Clear a factory flag in case it was a factory.
+         * If needs be, it will get re-added after this function completes.
+         */
+        unset($this->factoryIds[$id]);
 
         $this->services[$id] = $service;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR removes the `ContainerConfigurator::hasService` check inside `ContainerConfigurator::addService`.

This is unnecessary and potentially expensive (especially with large and/or multiple and/or composite containers).

Previously, there was an exception thrown in case someone wanted to register a module with an existing ID. In https://github.com/inpsyde/modularity/commit/74cf1a5bba4913a4ecb1f1db714fdbd047d13e3b, the exception has been removed (for the reasons mentioned in #17).

This means, previously, we **needed to know** if there already is a service with the given ID. Now, we **don't care**, and we can simply `unset` the potentially-existing service as `unset($foo)` does not care whether `$foo` exists.

**What is the current behavior?** (You can also link to an open issue here)

Calling `ContainerConfigurator::addService` will internally call `ContainerConfigurator::hasService`.

**What is the new behavior (if this is a feature change)?**

Calling `ContainerConfigurator::addService` will attempt to unset the entry in the factory lookup table without checking if it exists first.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:
