### PR TITLE
Fix PHPUnit tests not running in CI and failing test

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -46,7 +46,7 @@ jobs:
           dependency-versions: ${{ matrix.dependency-versions }}
 
       - name: Run unit tests
-        run:
+        run: |
           ./vendor/bin/phpunit --atleast-version 9 && ./vendor/bin/phpunit --migrate-configuration || echo 'Config does not need updates.'
           ./vendor/bin/phpunit ${{ ((env.USE_COVERAGE == 'yes') && '--coverage-clover coverage.xml') || '--no-coverage' }}
 

--- a/tests/unit/PackageTest.php
+++ b/tests/unit/PackageTest.php
@@ -261,7 +261,7 @@ class PackageTest extends TestCase
     {
         $package = Package::new($this->mockProperties('test', true))->build();
 
-        $this->expectExceptionMessageMatches("/add module.+?status.+?at end of building stage/i");
+        $this->expectExceptionMessageMatches("/can't add module/i");
 
         $package->addModule($this->mockModule());
     }

--- a/tests/unit/PackageTest.php
+++ b/tests/unit/PackageTest.php
@@ -850,7 +850,7 @@ class PackageTest extends TestCase
         static::assertSame('service_1', $container->get('service_1')['id']);
         static::assertSame('service_2', $container->get('service_2')['id']);
 
-        $this->expectExceptionMessageMatches('/add module module_3/i');
+        $this->expectExceptionMessageMatches("/can't add module module_3/i");
         $this->ignoreDeprecations();
         $package->boot($module2, $module3);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It fixes a failing test and the CI where PHPUnit tests are not actually run.

**What is the current behavior?** (You can also link to an open issue here)

There's a failing test, but that is never caught because the PHPUnit tests are not run.

**What is the new behavior (if this is a feature change)?**

PHPUnit runs again in the CI, and the failing test passes.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:

None.