### PR TITLE
Fix Theme Properties referencing nonexistent file headers

### DIFF
--- a/src/Properties/ThemeProperties.php
+++ b/src/Properties/ThemeProperties.php
@@ -26,15 +26,15 @@ class ThemeProperties extends BaseProperties
      */
     protected const HEADERS = [
         self::PROP_AUTHOR => 'Author',
-        self::PROP_AUTHOR_URI => 'Author URI',
+        self::PROP_AUTHOR_URI => 'AuthorURI',
         self::PROP_DESCRIPTION => 'Description',
-        self::PROP_DOMAIN_PATH => 'Domain Path',
-        self::PROP_NAME => 'Theme Name',
-        self::PROP_TEXTDOMAIN => 'Text Domain',
-        self::PROP_URI => 'Theme URI',
+        self::PROP_DOMAIN_PATH => 'DomainPath',
+        self::PROP_NAME => 'Name',
+        self::PROP_TEXTDOMAIN => 'TextDomain',
+        self::PROP_URI => 'ThemeURI',
         self::PROP_VERSION => 'Version',
-        self::PROP_REQUIRES_WP => 'Requires at least',
-        self::PROP_REQUIRES_PHP => 'Requires PHP',
+        self::PROP_REQUIRES_WP => 'RequiresWP',
+        self::PROP_REQUIRES_PHP => 'RequiresPHP',
 
         // additional headers
         self::PROP_STATUS => 'Status',

--- a/tests/unit/Properties/ThemePropertiesTest.php
+++ b/tests/unit/Properties/ThemePropertiesTest.php
@@ -26,7 +26,7 @@ class ThemePropertiesTest extends TestCase
         $expectedUri = 'http://github.com/inpsyde/modularity';
         $expectedVersion = '1.0';
         $expectedPhpVersion = "7.4";
-        $expecteWpVersion = "5.3";
+        $expectedWpVersion = "5.3";
         $expectedStatus = 'publish';
         $expectedTags = ['foo', 'bar'];
 
@@ -36,15 +36,15 @@ class ThemePropertiesTest extends TestCase
 
         $values = [
             'Author' => $expectedAuthor,
-            'Author URI' => $expectedAuthorUri,
+            'AuthorURI' => $expectedAuthorUri,
             'Description' => $expectedDescription,
-            'Domain Path' => $expectedDomainPath,
-            'Theme Name' => $expectedName,
-            'Text Domain' => $expectedTextDomain,
-            'Theme URI' => $expectedUri,
+            'DomainPath' => $expectedDomainPath,
+            'Name' => $expectedName,
+            'TextDomain' => $expectedTextDomain,
+            'ThemeURI' => $expectedUri,
             'Version' => $expectedVersion,
-            'Requires at least' => $expecteWpVersion,
-            'Requires PHP' => $expectedPhpVersion,
+            'RequiresWP' => $expectedWpVersion,
+            'RequiresPHP' => $expectedPhpVersion,
             'Status' => $expectedStatus,
             'Tags' => $expectedTags,
             // No child-Theme.
@@ -78,7 +78,7 @@ class ThemePropertiesTest extends TestCase
         static::assertSame($expectedTextDomain, $testee->textDomain());
         static::assertSame($expectedUri, $testee->uri());
         static::assertSame($expectedVersion, $testee->version());
-        static::assertSame($expecteWpVersion, $testee->requiresWp());
+        static::assertSame($expectedWpVersion, $testee->requiresWp());
         static::assertSame($expectedPhpVersion, $testee->requiresPhp());
 
         // specific methods for Themes.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It fixes the retrieval of theme information defined in the file header.

**What is the current behavior?** (You can also link to an open issue here)

We are trying to access the file header information using the "display name".

**What is the new behavior (if this is a feature change)?**

We are accessing the file header using the keys.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:

None.