### PR TITLE
Update docs for deprecated usage of `Package::boot()`

### DIFF
--- a/docs/Package.md
+++ b/docs/Package.md
@@ -248,7 +248,9 @@ function myLibrary(): Package {
     if (!$lib) {
         $properties = Properties\LibraryProperties::new('path/to/composer.json');
         $lib = Inpsyde\Modularity\Package::new($properties);
-        $lib->boot(new ModuleOne(), new ModuleTwo());
+        $lib->addModule(new ModuleOne());
+        $lib->addModule(new ModuleTwo());
+        $lib->boot();
     }
     return $lib;
 }

--- a/src/Package.php
+++ b/src/Package.php
@@ -118,7 +118,7 @@ class Package
      * <code>
      * $package = Package::new();
      * $package->moduleIs(SomeModule::class, Package::MODULE_ADDED); // false
-     * $package->boot(new SomeModule());
+     * $package->addModule(new SomeModule());
      * $package->moduleIs(SomeModule::class, Package::MODULE_ADDED); // true
      * </code>
      */


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Update docs so they no longer include deprecated functionality.

**What is the current behavior?** (You can also link to an open issue here)

Currently, two pieces of documentation include the deprecated usage of `Package::boot()` with one or more module instances being passed to the method.

**What is the new behavior (if this is a feature change)?**

The documentation shows adding modules and booting the package in separate calls to `addModule()` and `boot()`, respectively.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:
