### PR TITLE
Avoid early call to wptexturize

### DIFF
--- a/src/Properties/PluginProperties.php
+++ b/src/Properties/PluginProperties.php
@@ -86,6 +86,7 @@ class PluginProperties extends BaseProperties
         }
         
         // $markup = false, to avoid an incorrect early wptexturize call. Also we probably don't want HTML here anyway
+        // @see https://core.trac.wordpress.org/ticket/49965
         $pluginData = get_plugin_data($pluginMainFile, false);
         $properties = Properties::DEFAULT_PROPERTIES;
 

--- a/src/Properties/PluginProperties.php
+++ b/src/Properties/PluginProperties.php
@@ -84,8 +84,9 @@ class PluginProperties extends BaseProperties
         if (!function_exists('get_plugin_data')) {
             require_once ABSPATH . 'wp-admin/includes/plugin.php';
         }
-
-        $pluginData = get_plugin_data($pluginMainFile);
+        
+        // $markup = false, to avoid an incorrect early wptexturize call. Also we probably don't want HTML here anyway
+        $pluginData = get_plugin_data($pluginMainFile, false);
         $properties = Properties::DEFAULT_PROPERTIES;
 
         // Map pluginData to internal structure.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)

In `PluginProperties`, we call `get_plugin_data()`.
With default parameters, this triggers a call to `wptexturize()` which can result in wrong quotes being used throughout the entire website if called too early. There is a TRAC ticket for this here:
https://core.trac.wordpress.org/ticket/49965

**What is the new behavior (if this is a feature change)?**
We pass `$markup=true` in order to skip HTML generation - and with it the call to `wptexturize`


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
If you have previously relied on `$data['PluginURI']` and `$data['AuthorURI']` to be wrapped in `<a>` tags, then this needs to be added manualls now.
On the flipside, we actually receive the raw data now which might be preferrable withing the service resolution environment int's intended for.


**Other information**:
I am aware that we are not **solving** the issue here. We're just pushing it away a bit.
At the same time, hooking modularity in `plugins_loaded` (or a similar, very early stage) is a very common thing to do.
This means that a huge chunk of our work based on modularity may expose this bug to client systems and this is an effort to stay on the safe side without causing too much noise.