### PR TITLE
PluginProperties: Add support for Requires Plugins header

### DIFF
--- a/src/Properties/PluginProperties.php
+++ b/src/Properties/PluginProperties.php
@@ -17,6 +17,7 @@ class PluginProperties extends BaseProperties
      * Custom properties for Plugins.
      */
     public const PROP_NETWORK = 'network';
+    public const PROP_REQUIRES_PLUGINS = 'requiresPlugins';
     /**
      * Available methods of Properties::__call()
      * from plugin headers.
@@ -37,6 +38,7 @@ class PluginProperties extends BaseProperties
 
         // additional headers
         self::PROP_NETWORK => 'Network',
+        self::PROP_REQUIRES_PLUGINS => 'RequiresPlugins',
     ];
 
     /**
@@ -84,7 +86,7 @@ class PluginProperties extends BaseProperties
         if (!function_exists('get_plugin_data')) {
             require_once ABSPATH . 'wp-admin/includes/plugin.php';
         }
-        
+
         // $markup = false, to avoid an incorrect early wptexturize call. Also we probably don't want HTML here anyway
         // @see https://core.trac.wordpress.org/ticket/49965
         $pluginData = get_plugin_data($pluginMainFile, false);
@@ -127,6 +129,16 @@ class PluginProperties extends BaseProperties
     public function network(): bool
     {
         return (bool) $this->get(self::PROP_NETWORK, false);
+    }
+
+    /**
+     * @return array
+     */
+    public function requiresPlugins(): array
+    {
+        $value = $this->get(self::PROP_REQUIRES_PLUGINS);
+
+        return $value && is_string($value) ? explode(',', $value) : [];
     }
 
     /**

--- a/tests/unit/Properties/PluginPropertiesTest.php
+++ b/tests/unit/Properties/PluginPropertiesTest.php
@@ -75,6 +75,61 @@ class PluginPropertiesTest extends TestCase
     }
 
     /**
+     * @param string $requiresPlugins
+     * @param array $expected
+     *
+     * @test
+     *
+     * @runInSeparateProcess
+     *
+     * @dataProvider provideRequiresPluginsData
+     */
+    public function testRequiresPlugins(string $requiresPlugins, array $expected): void
+    {
+        $pluginMainFile = '/app/wp-content/plugins/plugin-dir/plugin-name.php';
+        $expectedBaseName = 'plugin-dir/plugin-name.php';
+
+        Functions\expect('get_plugin_data')->andReturn([
+            'RequiresPlugins' => $requiresPlugins,
+        ]);
+        Functions\when('plugins_url')->returnArg(1);
+        Functions\expect('plugin_basename')->andReturn($expectedBaseName);
+        Functions\when('plugin_dir_path')->returnArg(1);
+
+        Functions\expect('wp_normalize_path')->andReturnFirstArg();
+
+        $testee = PluginProperties::new($pluginMainFile);
+        static::assertEquals($expected, $testee->requiresPlugins());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideRequiresPluginsData(): array
+    {
+        return [
+            'no dependencies' => [
+                '',
+                [],
+            ],
+            'one dependency' => [
+                'dependency',
+                [
+                    'dependency',
+                ],
+            ],
+            'multiple dependencies' => [
+                'dependency1,dependency2,dependency3',
+                [
+                    'dependency1',
+                    'dependency2',
+                    'dependency3',
+                ],
+            ],
+        ];
+    }
+
+    /**
      * @test
      */
     public function testIsActive(): void


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds support for the new `Requires Plugins` header.

**What is the current behavior?** (You can also link to an open issue here)

Plugin dependencies declared in a plugin's headers are not available.

**What is the new behavior (if this is a feature change)?**

The `PluginProperties` class exposes any plugin dependencies declared in a plugin's headers via the new `requiresPlugins` method.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

In terms of Modularity itself, no. However, if someone extended the `PluginProperties` class and declared a custom method `requiresPlugins`, PHP will complain if the signature is not the same.

**Other information**:
