### PR TITLE
Use `PATHINFO_BASENAME` for interoperability

### DIFF
--- a/src/Properties/BaseProperties.php
+++ b/src/Properties/BaseProperties.php
@@ -64,7 +64,7 @@ class BaseProperties implements Properties
     {
         substr_count($name, '/') and $name = dirname($name);
 
-        return strtolower(pathinfo($name, PATHINFO_FILENAME));
+        return strtolower(pathinfo($name, PATHINFO_BASENAME));
     }
 
     /**


### PR DESCRIPTION
The usage of the flag `PATHINFO_FILENAME` might strip part of the  name of the project. 

One case might be a theme having a dot as part of the name, for instance when we want to differentiate the different versions of a theme we have in our installation.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
The project base name is stripping part of the name when defining the `baseName` property


**What is the new behavior (if this is a feature change)?**
The part after the dot (.) character is no longer stripped off.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
