### PR TITLE
Introduce service extensions by type

### DIFF
--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -180,7 +180,7 @@ Inside each of the three "groups", extensions are processed in _FIFO_ mode: the 
 first processed.
 
 Because the precedence rules, in the `SomethingExtensionsModule` example above, the extensions
-processing order will be the the inverse of the addition order.
+processing order will be the inverse of the addition order.
 
 #### Only for objects
 

--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -134,8 +134,8 @@ extension to anything implementing `LoggerAwareInterface`.
 
 #### Types and subtypes
 
-The `@instanceof<T>` syntax also work with class names, targeting the given class or any of its 
-sub types.
+The `@instanceof<T>` syntax also works with class names, targeting the given class or any of its 
+subtypes.
 
 For example, assuming the following objects:
 

--- a/src/Container/ContainerConfigurator.php
+++ b/src/Container/ContainerConfigurator.php
@@ -19,9 +19,9 @@ class ContainerConfigurator
     private $factoryIds = [];
 
     /**
-     * @var array<string, array<callable(mixed $service, ContainerInterface $container):mixed>>
+     * @var ServiceExtensions
      */
-    private $extensions = [];
+    private $extensions;
 
     /**
      * @var ContainerInterface[]
@@ -38,9 +38,10 @@ class ContainerConfigurator
      *
      * @param ContainerInterface[] $containers
      */
-    public function __construct(array $containers = [])
+    public function __construct(array $containers = [], ?ServiceExtensions $extensions = null)
     {
         array_map([$this, 'addContainer'], $containers);
+        $this->extensions = $extensions ?? new ServiceExtensions();
     }
 
     /**
@@ -115,11 +116,7 @@ class ContainerConfigurator
      */
     public function addExtension(string $id, callable $extender): void
     {
-        if (!isset($this->extensions[$id])) {
-            $this->extensions[$id] = [];
-        }
-
-        $this->extensions[$id][] = $extender;
+        $this->extensions->add($id, $extender);
     }
 
     /**
@@ -129,7 +126,7 @@ class ContainerConfigurator
      */
     public function hasExtension(string $id): bool
     {
-        return isset($this->extensions[$id]);
+        return $this->extensions->has($id);
     }
 
     /**

--- a/src/Container/ServiceExtensions.php
+++ b/src/Container/ServiceExtensions.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inpsyde\Modularity\Container;
+
+use Psr\Container\ContainerInterface as Container;
+
+class ServiceExtensions
+{
+    private const SERVICE_TYPE_NOT_CHANGED = 1;
+    private const SERVICE_TYPE_CHANGED = 2;
+    private const SERVICE_TYPE_NOT_OBJECT = 0;
+
+    /**
+     * @var array<string, list<callable>>
+     */
+    protected $extensions = [];
+
+    /**
+     * @param string $type
+     * @return string
+     */
+    final public static function typeId(string $type): string
+    {
+        return "@instanceof<{$type}>";
+    }
+
+    /**
+     * @param string $extensionId
+     * @param callable $extender
+     * @return static
+     */
+    public function add(string $extensionId, callable $extender): ServiceExtensions
+    {
+        isset($this->extensions[$extensionId]) or $this->extensions[$extensionId] = [];
+        $this->extensions[$extensionId][] = $extender;
+
+        return $this;
+    }
+
+    /**
+     * @param string $extensionId
+     * @return bool
+     */
+    public function has(string $extensionId): bool
+    {
+        return isset($this->extensions[$extensionId]);
+    }
+
+    /**
+     * @param mixed $service
+     * @param string $id
+     * @param Container $container
+     * @return mixed
+     */
+    final public function resolve($service, string $id, Container $container)
+    {
+        $service = $this->resolveById($id, $service, $container);
+
+        return is_object($service)
+            ? $this->resolveByType(get_class($service), $service, $container)
+            : $service;
+    }
+
+    /**
+     * @param string $id
+     * @param mixed $service
+     * @param Container $container
+     * @return mixed
+     */
+    protected function resolveById(string $id, $service, Container $container)
+    {
+        foreach ($this->extensions[$id] ?? [] as $extender) {
+            $service = $extender($service, $container);
+        }
+
+        return $service;
+    }
+
+    /**
+     * @param string $className
+     * @param object $service
+     * @param Container $container
+     * @param array $extendedClasses
+     * @return mixed
+     */
+    protected function resolveByType(
+        string $className,
+        object $service,
+        Container $container,
+        array $extendedClasses = []
+    ) {
+
+        $extendedClasses[] = $className;
+
+        /** @var array<class-string, list<callable>> $allCallbacks */
+        $allCallbacks = [];
+
+        // 1st group of extensions: targeting exact class
+        $byClass = $this->extensions[self::typeId($className)] ?? null;
+        $byClass and $allCallbacks[$className] = $byClass;
+
+        // 2nd group of extensions: targeting parent classes
+        /** @var class-string $parentName */
+        foreach (class_parents($service, false) ?: [] as $parentName) {
+            $byParent = $this->extensions[self::typeId($parentName)] ?? null;
+            $byParent and $allCallbacks[$parentName] = $byParent;
+        }
+
+        // 3rd group of extensions: targeting implemented interfaces
+        /** @var class-string $interfaceName */
+        foreach (class_implements($service, false) ?: [] as $interfaceName) {
+            $byInterface = $this->extensions[self::typeId($interfaceName)] ?? null;
+            $byInterface and $allCallbacks[$interfaceName] = $byInterface;
+        }
+
+        $resultType = self::SERVICE_TYPE_NOT_CHANGED;
+        /** @var class-string $type */
+        foreach ($allCallbacks as $type => $extenders) {
+            // When the previous group of callbacks resulted in a type change, we need to check
+            // type before processing next group.
+            if (($resultType === self::SERVICE_TYPE_CHANGED) && !is_a($service, $type)) {
+                continue;
+            }
+            [$service, $resultType] = $this->extendByType($type, $service, $container, $extenders);
+            if ($resultType === self::SERVICE_TYPE_NOT_OBJECT) {
+                // Service is not an object anymore, let's return it.
+                return $service;
+            }
+        }
+
+        // If type changed since beginning, let's start over.
+        // We check if class was already extended to avoid infinite recursion. E.g. instead of:
+        // `-> extend(A): B -> extend(B): A -> *loop* ->`
+        // we have:
+        // `-> extend(A): B -> extend(B): A -> return A`.
+        $newClassName = get_class($service);
+        if (!in_array($newClassName, $extendedClasses, true)) {
+            return $this->resolveByType($newClassName, $service, $container, $extendedClasses);
+        }
+
+        return $service;
+    }
+
+    /**
+     * @param class-string $type
+     * @param object $service
+     * @param Container $container
+     * @param array $extenders
+     * @return array{mixed, int}
+     */
+    private function extendByType(
+        string $type,
+        object $service,
+        Container $container,
+        array $extenders
+    ): array {
+
+        foreach ($extenders as $extender) {
+            $service = $extender($service, $container);
+            if (!is_object($service)) {
+                return [$service, self::SERVICE_TYPE_NOT_OBJECT];
+            }
+            if (!is_a($service, $type)) {
+                return [$service, self::SERVICE_TYPE_CHANGED];
+            }
+        }
+
+        return [$service, self::SERVICE_TYPE_NOT_CHANGED];
+    }
+}

--- a/tests/unit/Container/ContainerConfiguratorTest.php
+++ b/tests/unit/Container/ContainerConfiguratorTest.php
@@ -241,7 +241,7 @@ class ContainerConfiguratorTest extends TestCase
     /**
      * @test
      */
-    public function testAddExtension(): void
+    public function testExtensionById(): void
     {
         $testee = new ContainerConfigurator();
 
@@ -286,6 +286,247 @@ class ContainerConfiguratorTest extends TestCase
         static::assertTrue($testee->hasService($expectedKey));
         static::assertTrue($testee->hasExtension($expectedKey));
         static::assertSame($expectedExtendedValue, $testee->createReadOnlyContainer()->get($expectedKey));
+    }
+
+    /**
+     * @test
+     */
+    public function testExtensionByType(): void
+    {
+        $string = 'Test';
+        $array = ['test' => 'Test'];
+        $iterator = new \ArrayIterator($array);
+        $object = (object)$array;
+        $int = 0;
+
+        $configurator = new ContainerConfigurator();
+
+        $services = compact('string', 'array', 'iterator', 'object', 'int');
+        $container = new class ($services) extends \ArrayObject implements ContainerInterface
+        {
+            public function get(string $id)
+            {
+                return $this[$id] ?? null;
+            }
+
+            public function has(string $id): bool
+            {
+                return $this->offsetExists($id);
+            }
+        };
+
+        $configurator->addContainer($container);
+
+        $configurator->addExtension(
+            '@instanceof<ArrayIterator>',
+            function (\ArrayIterator $object): array {
+                $array = $object->getArrayCopy();
+                $array['works'] = 'Works!';
+
+                return $array;
+            }
+        );
+
+        $configurator->addExtension(
+            '@instanceof<string>',
+            function (): string {
+                throw new \Error('Failed!');
+            }
+        );
+        // Invalid code does not break resolution
+        $configurator->addExtension(
+            '@instanceof<This-Is-Not-Valid-Code!>',
+            function (): array {
+                throw new \Error('Failed!');
+            }
+        );
+        // Undefined classes are ignored
+        $configurator->addExtension(
+            '@instanceof<ThisCouldBeValidClassNameButItDoesNotExists>',
+            function (): array {
+                throw new \Error('Failed!');
+            }
+        );
+        // This is fine, but we don't expect it running because there are no stdClass in services
+        $configurator->addExtension(
+            '@instanceof<stdClass>',
+            function (\stdClass $object): \stdClass {
+                $array = get_object_vars($object);
+                $array['works'] = 'Works!';
+                return (object)$array;
+            }
+        );
+        $configurator->addExtension(
+            '@instanceof<bool>',
+            function (): bool {
+                throw new \Error('Failed!');
+            }
+        );
+        $configurator->addExtension(
+            '@instanceof<int>',
+            function (): int {
+                throw new \Error('Failed!');
+            }
+        );
+
+        $container = $configurator->createReadOnlyContainer();
+
+        static::assertSame(
+            ['test' => 'Test', 'works' => 'Works!'],
+            $container->get('iterator')
+        );
+
+        static::assertSame(
+            ['test' => 'Test', 'works' => 'Works!'],
+            (array)$container->get('object')
+        );
+
+        static::assertSame('Test', $container->get('string'));
+        static::assertSame(['test' => 'Test'], $container->get('array'));
+        static::assertSame(0, $container->get('int'));
+    }
+
+    /**
+     * @test
+     * @runInSeparateProcess
+     *
+     * @noinspection PhpUndefinedClassInspection
+     */
+    public function testExtensionByTypeNoInfiniteRecursion(): void
+    {
+        // We can't declare classes inside a class, but we can eval it.
+        $php = <<<'PHP'
+        class A {}
+        class B extends A {}
+        PHP;
+        eval($php);
+
+        $called = [];
+
+        $configurator = new ContainerConfigurator();
+        $configurator->addService('test', static function (): \A {
+            return new \A();
+        });
+        $configurator->addExtension(
+            '@instanceof<B>',
+            static function (\B $object) use (&$called): \B {
+                $called[] = 'instanceof<B>';
+                return $object;
+            }
+        );
+        $configurator->addExtension(
+            '@instanceof<A>',
+            static function () use (&$called): \B {
+                $called[] = 'instanceof<A>';
+                return new \B();
+            }
+        );
+
+        $object = $configurator->createReadOnlyContainer()->get('test');
+        static::assertTrue($object instanceof \B);
+        static::assertSame(['instanceof<A>', 'instanceof<B>', 'instanceof<A>'], $called);
+    }
+
+    /**
+     * @test
+     * @runInSeparateProcess
+     *
+     * @noinspection PhpUndefinedClassInspection
+     * @noinspection PhpIncompatibleReturnTypeInspection
+     */
+    public function testExtensionByTypeNested(): void
+    {
+        $logs = [];
+        $log = static function (object $object, int ...$nums) use (&$logs): object {
+            foreach ($nums as $num) {
+                if (!in_array($num, $logs, true)) {
+                    $logs[] = $num;
+                    break;
+                }
+            }
+            return $object;
+        };
+
+        $configurator = new ContainerConfigurator();
+        $configurator->addService('test', function () {
+            return new \ArrayObject();
+        });
+
+        // We can't declare classes inside a class, but we can eval it.
+        $php = <<<'PHP'
+        class A {}
+        class B extends A {}
+        class C {}
+        class D {};
+        class E extends D {};
+        PHP;
+        eval($php);
+
+        $configurator->addExtension(
+            '@instanceof<D>', static function (\D $o) use (&$log): \E {
+                return $log(new \E(), 6, 9);
+            }
+        );
+        $configurator->addExtension(
+            '@instanceof<A>',
+            static function (\A $o) use (&$log): \A {
+                return $log($o, -1); // we never expect this to run
+            }
+        );
+        $configurator->addExtension(
+            '@instanceof<ArrayAccess>',
+            static function (\ArrayAccess $o) use (&$log): \ArrayAccess  {
+                return $log($o, 2);
+            }
+        );
+        $configurator->addExtension(
+            "@instanceof<B>",
+            static function (\B $o) use (&$log): \C {
+                return $log(new \C(), 4);
+            }
+        );
+        $configurator->addExtension(
+            'test',
+            static function (object $o) use ($log): object {
+                return $log($o, 0);
+            }
+        );
+        $configurator->addExtension(
+            '@instanceof<ArrayObject>',
+            static function (\ArrayObject $o) use (&$log): \ArrayObject {
+                return $log($o, 1);
+            }
+        );
+        $configurator->addExtension(
+            '@instanceof<C>',
+            static function (\C $o) use (&$log): \D {
+                return $log(new \D(), 5);
+            }
+        );
+        $configurator->addExtension(
+            '@instanceof<ArrayAccess>',
+            static function (\ArrayAccess $o) use (&$log): \B {
+                return $log(new \B(), 3);
+            }
+        );
+        $configurator->addExtension(
+            "@instanceof<E>",
+            static function (\E $o) use (&$log): \E {
+                return $log($o, 8);
+            }
+        );
+        $configurator->addExtension(
+            "@instanceof<D>",
+            static function (\D $o) use (&$log): \D {
+                return $log($o, 7, 10);
+            }
+        );
+
+        $service = $configurator->createReadOnlyContainer()->get('test');
+
+        static::assertTrue($service instanceof \E);
+        // test the order of callbacks was the one expected
+        static::assertSame(range(0, 10), $logs);
     }
 
     /**

--- a/tests/unit/Container/ContainerConfiguratorTest.php
+++ b/tests/unit/Container/ContainerConfiguratorTest.php
@@ -396,9 +396,10 @@ class ContainerConfiguratorTest extends TestCase
     {
         // We can't declare classes inside a class, but we can eval it.
         $php = <<<'PHP'
-        class A {}
-        class B extends A {}
-        PHP;
+class A {}
+class B extends A {}
+PHP;
+
         eval($php);
 
         $called = [];
@@ -454,12 +455,12 @@ class ContainerConfiguratorTest extends TestCase
 
         // We can't declare classes inside a class, but we can eval it.
         $php = <<<'PHP'
-        class A {}
-        class B extends A {}
-        class C {}
-        class D {};
-        class E extends D {};
-        PHP;
+class A {}
+class B extends A {}
+class C {}
+class D {};
+class E extends D {};
+PHP;
         eval($php);
 
         $configurator->addExtension(

--- a/tests/unit/Container/ReadOnlyContainerTest.php
+++ b/tests/unit/Container/ReadOnlyContainerTest.php
@@ -164,6 +164,37 @@ class ReadOnlyContainerTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function testServiceExtensionsBackwardCompatibility(): void
+    {
+        $service = static fn (): object => (object) ['count' => 0];
+
+        $extension = static function (object $thing): object {
+            $thing->count++;
+
+            return $thing;
+        };
+
+        $container = new Container(['thing' => $service], [], ['thing' => $extension], []);
+
+        $resolved = $container->get('thing');
+
+        static::assertInstanceOf(\stdClass::class, $resolved);
+        static::assertSame(1, $resolved->count);
+    }
+
+    /**
+     * @test
+     */
+    public function testServiceExtensionsBackwardCompatibilityBreaksOnWrongType(): void
+    {
+        $this->expectException(\TypeError::class);
+
+        new Container([], [], ServiceExtensions::class, []);
+    }
+
+    /**
      * @param array $services
      * @param array $factoryIds
      * @param array $containers

--- a/tests/unit/Container/ReadOnlyContainerTest.php
+++ b/tests/unit/Container/ReadOnlyContainerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Inpsyde\Modularity\Tests\Unit\Container;
 
 use Inpsyde\Modularity\Container\ReadOnlyContainer as Container;
+use Inpsyde\Modularity\Container\ServiceExtensions;
 use Inpsyde\Modularity\Tests\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -105,7 +106,7 @@ class ReadOnlyContainerTest extends TestCase
             }
         };
 
-        $testee = $this->createContainer([], [], [], [$childContainer]);
+        $testee = $this->createContainer([], [], [$childContainer]);
 
         // check in child Container
         static::assertTrue($testee->has($expectedServiceKey));
@@ -113,35 +114,6 @@ class ReadOnlyContainerTest extends TestCase
         static::assertSame($expectedValue, $testee->get($expectedServiceKey));
         // check in resolved Services
         static::assertTrue($testee->has($expectedServiceKey));
-    }
-
-    /**
-     * @test
-     */
-    public function testExtensions(): void
-    {
-        $expectedServiceKey = 'service';
-        $expectedInitialService = new \stdClass();
-        $extendedService = new \stdClass();
-
-        $services = [
-            $expectedServiceKey => function () use ($expectedInitialService) {
-                return $expectedInitialService;
-            },
-        ];
-        $extensions = [
-            $expectedServiceKey => [
-                function ($initialService) use ($expectedInitialService, $extendedService) {
-                    static::assertSame($expectedInitialService, $initialService);
-
-                    return $extendedService;
-                },
-            ],
-        ];
-
-        $testee = $this->createContainer($services, [], $extensions);
-
-        static::assertSame($extendedService, $testee->get($expectedServiceKey));
     }
 
     /**
@@ -194,7 +166,6 @@ class ReadOnlyContainerTest extends TestCase
     /**
      * @param array $services
      * @param array $factoryIds
-     * @param array $extensions
      * @param array $containers
      *
      * @return Container
@@ -202,9 +173,9 @@ class ReadOnlyContainerTest extends TestCase
     private function createContainer(
         array $services = [],
         array $factoryIds = [],
-        array $extensions = [],
         array $containers = []
     ): Container {
-        return new Container($services, $factoryIds, $extensions, $containers);
+
+        return new Container($services, $factoryIds, new ServiceExtensions(), $containers);
     }
 }

--- a/tests/unit/Container/ReadOnlyContainerTest.php
+++ b/tests/unit/Container/ReadOnlyContainerTest.php
@@ -168,7 +168,9 @@ class ReadOnlyContainerTest extends TestCase
      */
     public function testServiceExtensionsBackwardCompatibility(): void
     {
-        $service = static fn (): object => (object) ['count' => 0];
+        $service = static function (): object {
+            return (object) ['count' => 0];
+        };
 
         $extension = static function (object $thing): object {
             $thing->count++;

--- a/tests/unit/Container/ServiceExtensionsTest.php
+++ b/tests/unit/Container/ServiceExtensionsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inpsyde\Modularity\Tests\Unit\Container;
+
+use Inpsyde\Modularity\Container\ServiceExtensions;
+use Inpsyde\Modularity\Tests\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+class ServiceExtensionsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function testBasicFunctionality(): void
+    {
+        $serviceExtensions = new ServiceExtensions();
+        $expected = 0;
+
+        $serviceExtensions->add(
+            'thing',
+            static function (object $thing) use (&$expected): object {
+                $thing->count++;
+                $expected++;
+
+                return $thing;
+            }
+        );
+
+        $serviceExtensions->add(
+            'nothing',
+            static function (object $thing): object {
+                $thing->count++;
+
+                return $thing;
+            }
+        );
+
+        $serviceExtensions->add(
+            'thing',
+            static function (object $thing) use (&$expected): object {
+                $thing->count++;
+                $expected++;
+
+                return $thing;
+            }
+        );
+
+        $serviceExtensions->add(
+            ServiceExtensions::typeId(\stdClass::class),
+            static function (object $thing) use (&$expected): object {
+                $thing->count++;
+                $expected++;
+
+                return $thing;
+            }
+        );
+
+        $serviceExtensions->add(
+            ServiceExtensions::typeId(\ArrayObject::class),
+            static function (object $thing): object {
+                $thing->count++;
+
+                return $thing;
+            }
+        );
+
+        $container = $this->stubContainer();
+        $thing = $serviceExtensions->resolve((object) ['count' => 0], 'thing', $container);
+
+        static::assertTrue($serviceExtensions->has('thing'));
+        static::assertTrue($serviceExtensions->has(ServiceExtensions::typeId(\stdClass::class)));
+        static::assertSame($expected, $thing->count);
+    }
+
+    /**
+     * @return ContainerInterface
+     */
+    private function stubContainer(): ContainerInterface
+    {
+        return new class implements ContainerInterface
+        {
+            public function get(string $id)
+            {
+                throw new class () extends \Exception implements NotFoundExceptionInterface
+                {
+                };
+            }
+
+            public function has(string $id): bool
+            {
+                return false;
+            }
+        };
+    }
+}


### PR DESCRIPTION
This PR introduces the possibility for `ExtendingModules` to declare extensions not only by specific ID but also by type.

Services' extension handling has been moved to a separate class (`Container\ServiceExtensions`) to facilitate and decouple the handling of the new, more advanced behavior.

An example taken from the updated docs:

```php
class LoggerAwareExtensionModule implements ExtendingModule
{
    use ModuleClassNameIdTrait;

    public function extensions() : array 
    {
        return [
            '@instanceof<' . LoggerAwareInterface::class . '>' => static function(
                LoggerAwareInterface $service,
                ContainerInterface $c
            ): ExtendedService {

                if ($c->has(LoggerInterface::class)) {
                    $service->setLogger($c->get(LoggerInterface::class));
                }

                return $service;
            }
        ];
    }
}
```

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

**What is the current behavior?** (You can also link to an open issue here)

Extensions need to target a specific service ID.

**What is the new behavior (if this is a feature change)?**

Extensions can also target a service type.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:
