### PR TITLE
Aligned behavior using build

### DIFF
--- a/src/Container/PackageProxyContainer.php
+++ b/src/Container/PackageProxyContainer.php
@@ -66,7 +66,8 @@ class PackageProxyContainer implements ContainerInterface
 
         /** TODO: We need a better way to deal with status checking besides equality */
         if (
-            $this->package->statusIs(Package::STATUS_READY)
+            $this->package->statusIs(Package::STATUS_INITIALIZED)
+            || $this->package->statusIs(Package::STATUS_READY)
             || $this->package->statusIs(Package::STATUS_BOOTED)
         ) {
             $this->container = $this->package->container();
@@ -88,7 +89,6 @@ class PackageProxyContainer implements ContainerInterface
         if ($this->tryContainer()) {
             return;
         }
-
         $name = $this->package->name();
         $status = $this->package->statusIs(Package::STATUS_FAILED)
             ? 'is errored'

--- a/tests/unit/PackageTest.php
+++ b/tests/unit/PackageTest.php
@@ -703,7 +703,7 @@ class PackageTest extends TestCase
     }
 
     /**
-     * Test we can not connect services when the package how call connect is built.
+     * Test we can not connect services when the package that calls connect() is built.
      *
      * @test
      */


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)

**Bug: Misaligned behavior with build**
The package has changed from using a boot method with passed modules to adding modules and having a build stage before boot. 

Not all the tests were aligned by the time the new approach was added. I added some tests to check the current behavior and found a couple of misalignments.

**Bug: Calling $package->build() several times change package status to STATUS_FAILED**


**What is the new behavior (if this is a feature change)?**
- It is not possible to connect packages if the caller is built.  Tests were added.
- It is possible to call `$package->build()` and the status of the package will not change.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Current consumers using the following code will have to adapt it. 
```PHP
$package1 = Package::new()->addModule($serviceModule1)->build();
$package2 = Package::new()->addModule($serviceModule2)->build();
$package2->connect($package1);
```


**Other information**:
We need to find a better way to get Container Status as mentioned in [here](https://github.com/inpsyde/modularity/blob/0bde4d19f3739c382faf4203aa707049de42563e/src/Container/PackageProxyContainer.php#L67)