### PR TITLE
Require PHP 7.4, Fix CS and QA

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -1,29 +1,60 @@
 name: Quality assurance PHP
 
-on: ['pull_request', 'push', 'workflow_dispatch']
+on:
+    push:
+        paths:
+            - '**workflows/php-qa.yml'
+            - '**.php'
+            - '**phpcs.xml.dist'
+            - '**psalm.xml'
+            - '**composer.json'
+    pull_request:
+        paths:
+            - '**workflows/php-qa.yml'
+            - '**.php'
+            - '**phpcs.xml.dist'
+            - '**psalm.xml'
+            - '**composer.json'
+    workflow_dispatch:
+        inputs:
+            jobs:
+                required: true
+                type: choice
+                default: 'Run all'
+                description: 'Choose jobs to run'
+                options:
+                    - 'Run all'
+                    - 'Run PHPCS only'
+                    - 'Run Psalm only'
+                    - 'Run lint only'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    group: "${{ github.workflow }}-${{ github.ref }}"
+    cancel-in-progress: true
 
 jobs:
-  lint-php:
-    if: ${{ (github.event_name == 'workflow_dispatch') || (!contains(github.event.head_commit.message, 'skip lint')) }}
-    strategy:
-      matrix:
-        php: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]
-    uses: inpsyde/reusable-workflows/.github/workflows/lint-php.yml@main
-    with:
-      PHP_VERSION: ${{ matrix.php }}
+    lint:
+        if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run lint only')) }}
+        uses: inpsyde/reusable-workflows/.github/workflows/lint-php.yml@main
+        strategy:
+            matrix:
+                php: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        with:
+            PHP_VERSION: ${{ matrix.php }}
+            LINT_ARGS: '-e php --colors --show-deprecated ./src'
 
-  coding-standards-analysis-php:
-    if: ${{ (github.event_name == 'workflow_dispatch') || (!contains(github.event.head_commit.message, 'skip cs')) }}
-    needs: lint-php
-    uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@main
-    with:
-      PHPCS_ARGS: '--report=summary'
+    coding-standards-analysis:
+        if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run PHPCS only')) }}
+        uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@main
+        with:
+            PHP_VERSION: '8.3'
 
-  static-analysis-php:
-    if: ${{ (github.event_name == 'workflow_dispatch') || (!contains(github.event.head_commit.message, 'skip sa')) }}
-    needs: lint-php
-    uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-php.yml@main
+    static-code-analysis:
+        if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run Psalm only')) }}
+        uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-php.yml@main
+        strategy:
+            matrix:
+                php: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        with:
+            PHP_VERSION: ${{ matrix.php }}
+            PSALM_ARGS: --output-format=github --no-suggestions --no-cache --no-diff --find-unused-psalm-suppress

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -60,7 +60,7 @@ jobs:
                     dependency-versions: ${{ matrix.dependency-versions }}
 
             -   name: Run unit tests
-                run: /vendor/bin/phpunit ${{ ((env.USE_COVERAGE == 'yes') && '--coverage-clover coverage.xml') || '--no-coverage' }}
+                run: ./vendor/bin/phpunit ${{ ((env.USE_COVERAGE == 'yes') && '--coverage-clover coverage.xml') || '--no-coverage' }}
 
             -   name: Update coverage
                 if: ${{ env.USE_COVERAGE == 'yes' }}

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -50,8 +50,8 @@ jobs:
 
             -   name: Setup dependencies for PSR-11 target version
                 run: |
-                    composer remove inpsyde/php-coding-standards inpsyde/wp-stubs-versions vimeo/psalm --dev --no-install
-                    composer require "psr/container:${{ matrix.container-versions }}" --no-install
+                    composer remove inpsyde/php-coding-standards inpsyde/wp-stubs-versions vimeo/psalm --dev --no-update
+                    composer require "psr/container:${{ matrix.container-versions }}" --no-update
 
             -   name: Install Composer dependencies
                 uses: ramsey/composer-install@v3

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -1,60 +1,71 @@
 name: PHP unit tests
 
-on: ['pull_request', 'push', 'workflow_dispatch']
+on:
+    push:
+        paths:
+            - '**workflows/php-unit-tests.yml'
+            - '**.php'
+            - '**phpunit.xml.dist'
+            - '**composer.json'
+    pull_request:
+        paths:
+            - '**workflows/php-unit-tests.yml'
+            - '**.php'
+            - '**phpunit.xml.dist'
+            - '**composer.json'
+    workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    group: "${{ github.workflow }}-${{ github.ref }}"
+    cancel-in-progress: true
 
 jobs:
-  tests-unit-php:
-    runs-on: ubuntu-latest
-    if: ${{ (github.event_name == 'workflow_dispatch') || (!contains(github.event.head_commit.message, 'skip tests')) }}
+    tests-unit-php:
+        runs-on: ubuntu-latest
+        if: ${{ (github.event_name == 'workflow_dispatch') || (!contains(github.event.head_commit.message, 'skip tests')) }}
 
-    env:
-      USE_COVERAGE: 'no'
+        env:
+            USE_COVERAGE: 'no'
 
-    strategy:
-      matrix:
-        php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
-        dependency-versions: [ 'lowest', 'highest' ]
-        container-versions: [ '^1.1.0', '^2' ]
+        strategy:
+            matrix:
+                php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+                dependency-versions: [ 'lowest', 'highest' ]
+                container-versions: [ '^1.1.0', '^2' ]
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v4
 
-      - name: Use coverage?
-        if: ${{ (matrix.php-versions == '8.0') && (matrix.dependency-versions == 'highest') && (matrix.container-versions == '^2') }}
-        run: echo "USE_COVERAGE=yes" >> $GITHUB_ENV
+            -   name: Use coverage?
+                if: ${{ (matrix.php-versions == '8.2') && (matrix.dependency-versions == 'highest') && (matrix.container-versions == '^2') }}
+                run: echo "USE_COVERAGE=yes" >> $GITHUB_ENV
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-versions }}
-          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
-          coverage: ${{ ((env.USE_COVERAGE == 'yes') && 'xdebug') || 'none' }}
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php-versions }}
+                    ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
+                    coverage: ${{ ((env.USE_COVERAGE == 'yes') && 'xdebug') || 'none' }}
 
-      - name: Setup dependencies for PSR-11 target version
-        run: |
-          composer remove inpsyde/php-coding-standards inpsyde/wp-stubs-versions vimeo/psalm --dev --no-install
-          composer require "psr/container:${{ matrix.container-versions }}" --no-install
+            -   name: Setup dependencies for PSR-11 target version
+                run: |
+                    composer remove inpsyde/php-coding-standards inpsyde/wp-stubs-versions vimeo/psalm --dev --no-install
+                    composer require "psr/container:${{ matrix.container-versions }}" --no-install
 
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
-        with:
-          dependency-versions: ${{ matrix.dependency-versions }}
+            -   name: Install Composer dependencies
+                uses: ramsey/composer-install@v3
+                with:
+                    dependency-versions: ${{ matrix.dependency-versions }}
 
-      - name: Run unit tests
-        run: |
-          ./vendor/bin/phpunit --atleast-version 9 && ./vendor/bin/phpunit --migrate-configuration || echo 'Config does not need updates.'
-          ./vendor/bin/phpunit ${{ ((env.USE_COVERAGE == 'yes') && '--coverage-clover coverage.xml') || '--no-coverage' }}
+            -   name: Run unit tests
+                run: /vendor/bin/phpunit ${{ ((env.USE_COVERAGE == 'yes') && '--coverage-clover coverage.xml') || '--no-coverage' }}
 
-      - name: Update coverage
-        if: ${{ env.USE_COVERAGE == 'yes' }}
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          flags: unittests
-          verbose: true
+            -   name: Update coverage
+                if: ${{ env.USE_COVERAGE == 'yes' }}
+                uses: codecov/codecov-action@v4
+                with:
+                    token: ${{ secrets.CODECOV_TOKEN }}
+                    files: ./coverage.xml
+                    flags: unittests
+                    verbose: true

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -52,6 +52,7 @@ jobs:
                 run: |
                     composer remove inpsyde/php-coding-standards inpsyde/wp-stubs-versions vimeo/psalm --dev --no-update
                     composer require "psr/container:${{ matrix.container-versions }}" --no-update
+                    composer config --no-plugins allow-plugins.roots/wordpress-core-installer false
 
             -   name: Install Composer dependencies
                 uses: ramsey/composer-install@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 ### Composer template
 composer.phar
 composer.lock
-/vendor/
+vendor/
 
 # PHPUnit
 .phpunit.result.cache
+phpunit.xml
+coverage/
 
 # tmp files
 tmp/

--- a/composer.json
+++ b/composer.json
@@ -9,31 +9,30 @@
             "email": "hello@inpsyde.com",
             "homepage": "https://inpsyde.com/",
             "role": "Company"
-        },
+        }
+    ],
+    "repositories": [
         {
-            "name": "Christian Leucht",
-            "email": "c.leucht@inpsyde.com",
-            "role": "Developer"
-        },
-        {
-            "name": "Giuseppe Mazzapica",
-            "email": "g.mazzapica@inpsyde.com",
-            "role": "Developer"
+            "type": "composer",
+            "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main",
+            "only": [
+                "inpsyde/wp-stubs-versions"
+            ]
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.4 <8.4",
         "ext-json": "*",
         "psr/container": "^1.1.0 || ^2"
     },
     "require-dev": {
         "brain/monkey": "^2.6.1",
-        "inpsyde/php-coding-standards": "^1",
-        "mikey179/vfsstream": "^v1.6.10",
-        "phpunit/phpunit": "^8.5.21 || ^9.6.7",
-        "vimeo/psalm": "^4.13.1",
-        "php-stubs/wordpress-stubs": ">=5.8@stable",
-        "johnpbloch/wordpress-core": ">=5.8"
+        "inpsyde/php-coding-standards": "^2@dev",
+        "inpsyde/wp-stubs-versions": "dev-latest",
+        "roots/wordpress-no-content": "@dev",
+        "mikey179/vfsstream": "^v1.6.11",
+        "phpunit/phpunit": "^9.6.19",
+        "vimeo/psalm": "^5.24.0"
     },
     "extra": {
         "branch-alias": {
@@ -55,19 +54,20 @@
     "prefer-stable": true,
     "scripts": {
         "cs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
-        "psalm": "@php ./vendor/vimeo/psalm/psalm",
+        "psalm": "@php ./vendor/vimeo/psalm/psalm --no-suggestions --report-show-info=false --find-unused-psalm-suppress --no-diff --no-cache --no-file-cache --output-format=compact",
+        "tests": "@php ./vendor/phpunit/phpunit/phpunit --no-coverage",
+        "tests:coverage": "@php ./vendor/phpunit/phpunit/phpunit",
         "qa": [
-            "@tests:no-cov",
             "@cs",
-            "@psalm"
-        ],
-        "tests": "@php ./vendor/phpunit/phpunit/phpunit",
-        "tests:no-cov": "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+            "@psalm",
+            "@tests"
+        ]
     },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/package-versions-deprecated": true
+            "composer/*": true,
+            "inpsyde/*": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -40,4 +40,7 @@
     <rule ref="WordPress.Security.EscapeOutput">
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
+    <rule ref="Squiz.PHP.Eval">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,19 +1,43 @@
 <?xml version="1.0"?>
 <ruleset>
-    <file>./src/</file>
-    <file>./tests/</file>
+    <file>./src</file>
+    <file>./tests</file>
 
     <arg value="sp"/>
     <arg name="colors"/>
-    <config name="testVersion" value="7.2-"/>
+    <config name="testVersion" value="7.4-"/>
     <config name="ignore_warnings_on_exit" value="1"/>
+
+    <rule ref="Inpsyde">
+        <exclude name="WordPress.PHP.DevelopmentFunctions.error_log_trigger_error" />
+    </rule>
 
     <rule ref="Inpsyde.CodeQuality.Psr4">
         <properties>
             <property
                 name="psr4"
                 type="array"
-                value="Inpsyde\Modularity=>src,Inpsyde\Modularity\Tests=>tests/src,Inpsyde\Modularity\Tests\Unit=>tests/unit"/>
+                value="
+                    Inpsyde\Modularity=>src,
+                    Inpsyde\Modularity\Tests=>tests/src,
+                    Inpsyde\Modularity\Tests\Unit=>tests/unit"
+            />
         </properties>
+    </rule>
+
+    <rule ref="Inpsyde.CodeQuality.FunctionLength">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+    <rule ref="Inpsyde.CodeQuality.ForbiddenPublicProperty">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+    <rule ref="WordPress.PHP.DevelopmentFunctions">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+    <rule ref="WordPress.PHP.DiscouragedPHPFunctions">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+    <rule ref="WordPress.Security.EscapeOutput">
+        <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,27 +1,32 @@
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
-         bootstrap="./tests/boot.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         convertDeprecationsToExceptions="false"
-         backupGlobals="false"
-         stopOnFailure="false">
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+<?xml version="1.0"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="./tests/boot.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    convertDeprecationsToExceptions="false"
+    backupGlobals="false"
+    stopOnFailure="false">
+
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">./src</directory>
-            <exclude>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>./vendor</directory>
+        </exclude>
+        <report>
+            <html outputDirectory="coverage"/>
+        </report>
+    </coverage>
+
     <testsuites>
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests/unit/</directory>
         </testsuite>
     </testsuites>
-    <logging>
-        <log type="coverage-html" target="tmp"/>
-    </logging>
+
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0"?>
 <psalm
+    errorLevel="1"
     useDocblockPropertyTypes="true"
     usePhpDocMethodsWithoutMagicCall="true"
     strictBinaryOperands="true"
     ignoreInternalFunctionFalseReturn="false"
     ignoreInternalFunctionNullReturn="false"
     hideExternalErrors="true"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
@@ -18,17 +21,12 @@
     </projectFiles>
 
     <stubs>
-        <file name="vendor/php-stubs/wordpress-stubs/wordpress-stubs.php" />
+        <file name="vendor/inpsyde/wp-stubs-versions/latest.php" />
     </stubs>
 
     <issueHandlers>
         <MixedAssignment errorLevel="suppress" />
-        <MissingClosureParamType errorLevel="suppress" />
-        <MissingClosureReturnType errorLevel="suppress" />
-        <ParadoxicalCondition errorLevel="suppress" />
-        <RedundantCondition errorLevel="suppress" />
         <UnresolvableInclude errorLevel="suppress" />
-        <UndefinedConstant errorLevel="suppress" />
-        <RedundantCastGivenDocblockType errorLevel="suppress" />
+        <MissingClassConstType errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/src/Container/ContainerConfigurator.php
+++ b/src/Container/ContainerConfigurator.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Inpsyde\Modularity\Container;
@@ -11,34 +12,16 @@ use Psr\Container\ContainerInterface;
  */
 class ContainerConfigurator
 {
-    /**
-     * @var array<string, Service>
-     */
-    private $services = [];
+    /** @var array<string, Service> */
+    private array $services = [];
+    /** @var array<string, bool> */
+    private array $factoryIds = [];
+    private ServiceExtensions $extensions;
+    private ?ContainerInterface $compiledContainer = null;
+    /** @var ContainerInterface[] */
+    private array $containers = [];
 
     /**
-     * @var array<string, bool>
-     */
-    private $factoryIds = [];
-
-    /**
-     * @var ServiceExtensions
-     */
-    private $extensions;
-
-    /**
-     * @var ContainerInterface[]
-     */
-    private $containers = [];
-
-    /**
-     * @var null|ContainerInterface
-     */
-    private $compiledContainer;
-
-    /**
-     * ContainerConfigurator constructor.
-     *
      * @param ContainerInterface[] $containers
      */
     public function __construct(array $containers = [], ?ServiceExtensions $extensions = null)
@@ -48,9 +31,8 @@ class ContainerConfigurator
     }
 
     /**
-     * Allowing to add child containers.
-     *
      * @param ContainerInterface $container
+     * @return void
      */
     public function addContainer(ContainerInterface $container): void
     {
@@ -72,7 +54,6 @@ class ContainerConfigurator
     /**
      * @param string $id
      * @param Service $service
-     *
      * @return void
      */
     public function addService(string $id, callable $service): void
@@ -93,7 +74,6 @@ class ContainerConfigurator
 
     /**
      * @param string $id
-     *
      * @return bool
      */
     public function hasService(string $id): bool
@@ -114,7 +94,6 @@ class ContainerConfigurator
     /**
      * @param string $id
      * @param ExtendingService $extender
-     *
      * @return void
      */
     public function addExtension(string $id, callable $extender): void
@@ -124,7 +103,6 @@ class ContainerConfigurator
 
     /**
      * @param string $id
-     *
      * @return bool
      */
     public function hasExtension(string $id): bool
@@ -133,13 +111,13 @@ class ContainerConfigurator
     }
 
     /**
-     * Returns a read only version of this Container.
-     *
      * @return ContainerInterface
+     *
+     * @psalm-assert ContainerInterface $this->compiledContainer
      */
     public function createReadOnlyContainer(): ContainerInterface
     {
-        if (!$this->compiledContainer) {
+        if ($this->compiledContainer === null) {
             $this->compiledContainer = new ReadOnlyContainer(
                 $this->services,
                 $this->factoryIds,

--- a/src/Container/PackageProxyContainer.php
+++ b/src/Container/PackageProxyContainer.php
@@ -55,9 +55,7 @@ class PackageProxyContainer implements ContainerInterface
 
         /** TODO: We need a better way to deal with status checking besides equality */
         if (
-            $this->package->statusIs(Package::STATUS_INITIALIZED)
-            || $this->package->statusIs(Package::STATUS_BOOTING)
-            || $this->package->statusIs(Package::STATUS_READY)
+            $this->package->statusIs(Package::STATUS_READY)
             || $this->package->statusIs(Package::STATUS_BOOTED)
         ) {
             $this->container = $this->package->container();

--- a/src/Container/PackageProxyContainer.php
+++ b/src/Container/PackageProxyContainer.php
@@ -10,15 +10,8 @@ use Psr\Container\ContainerInterface;
 
 class PackageProxyContainer implements ContainerInterface
 {
-    /**
-     * @var Package
-     */
-    private $package;
-
-    /**
-     * @var ContainerInterface|null
-     */
-    private $container;
+    private Package $package;
+    private ?ContainerInterface $container = null;
 
     /**
      * @param Package $package
@@ -31,8 +24,6 @@ class PackageProxyContainer implements ContainerInterface
     /**
      * @param string $id
      * @return mixed
-     *
-     * @throws \Exception
      */
     public function get(string $id)
     {
@@ -44,8 +35,6 @@ class PackageProxyContainer implements ContainerInterface
     /**
      * @param string $id
      * @return bool
-     *
-     * @throws \Exception
      */
     public function has(string $id): bool
     {
@@ -55,31 +44,31 @@ class PackageProxyContainer implements ContainerInterface
     /**
      * @return bool
      *
-     * @throws \Exception
      * @psalm-assert-if-true ContainerInterface $this->container
+     * @psalm-assert-if-false null $this->container
      */
     private function tryContainer(): bool
     {
-        if ($this->container) {
+        if ($this->container !== null) {
             return true;
         }
 
         /** TODO: We need a better way to deal with status checking besides equality */
         if (
-            $this->package->statusIs(Package::STATUS_READY)
+            $this->package->statusIs(Package::STATUS_INITIALIZED)
+            || $this->package->statusIs(Package::STATUS_BOOTING)
+            || $this->package->statusIs(Package::STATUS_READY)
             || $this->package->statusIs(Package::STATUS_BOOTED)
         ) {
             $this->container = $this->package->container();
         }
 
-        return (bool)$this->container;
+        return $this->container !== null;
     }
 
     /**
      * @param string $id
      * @return void
-     *
-     * @throws \Exception
      *
      * @psalm-assert ContainerInterface $this->container
      */
@@ -94,9 +83,9 @@ class PackageProxyContainer implements ContainerInterface
             ? 'is errored'
             : 'is not ready yet';
 
-        throw new class ("Error retrieving service {$id} because package {$name} {$status}.")
-            extends \Exception
-            implements ContainerExceptionInterface {
+        $error = "Error retrieving service {$id} because package {$name} {$status}.";
+        throw new class (esc_html($error)) extends \Exception implements ContainerExceptionInterface
+        {
         };
     }
 }

--- a/src/Container/ReadOnlyContainer.php
+++ b/src/Container/ReadOnlyContainer.php
@@ -13,36 +13,17 @@ use Psr\Container\NotFoundExceptionInterface;
  */
 class ReadOnlyContainer implements ContainerInterface
 {
-    /**
-     * @var array<string, Service>
-     */
-    private $services;
+    /** @var array<string, Service> */
+    private array $services;
+    /** @var array<string, bool> */
+    private array $factoryIds;
+    private ServiceExtensions $extensions;
+    /** @var ContainerInterface[] */
+    private array $containers;
+    /** @var array<string, mixed> */
+    private array $resolvedServices = [];
 
     /**
-     * @var array<string, bool>
-     */
-    private $factoryIds;
-
-    /**
-     * @var ServiceExtensions
-     */
-    private $extensions;
-
-    /**
-     * Resolved factories.
-     *
-     * @var array<string, mixed>
-     */
-    private $resolvedServices = [];
-
-    /**
-     * @var ContainerInterface[]
-     */
-    private $containers;
-
-    /**
-     * ReadOnlyContainer constructor.
-     *
      * @param array<string, Service> $services
      * @param array<string, bool> $factoryIds
      * @param ServiceExtensions|array $extensions
@@ -54,6 +35,7 @@ class ReadOnlyContainer implements ContainerInterface
         $extensions,
         array $containers
     ) {
+
         $this->services = $services;
         $this->factoryIds = $factoryIds;
         $this->extensions = $this->configureServiceExtensions($extensions);
@@ -62,7 +44,6 @@ class ReadOnlyContainer implements ContainerInterface
 
     /**
      * @param string $id
-     *
      * @return mixed
      */
     public function get(string $id)
@@ -91,15 +72,14 @@ class ReadOnlyContainer implements ContainerInterface
             }
         }
 
-        throw new class ("Service with ID {$id} not found.")
-            extends \Exception
-            implements NotFoundExceptionInterface {
+        $error = "Service with ID {$id} not found.";
+        throw new class (esc_html($error)) extends \Exception implements NotFoundExceptionInterface
+        {
         };
     }
 
     /**
      * @param string $id
-     *
      * @return bool
      */
     public function has(string $id): bool
@@ -138,13 +118,14 @@ class ReadOnlyContainer implements ContainerInterface
         }
 
         if (!is_array($extensions)) {
+            $type = is_object($extensions) ? get_class($extensions) : gettype($extensions);
             throw new \TypeError(
                 sprintf(
                     '%s::%s(): Argument #3 ($extensions) must be of type %s|array, %s given',
                     __CLASS__,
                     '__construct',
                     ServiceExtensions::class,
-                    gettype($extensions)
+                    esc_html($type)
                 )
             );
         }

--- a/src/Container/ServiceExtensions.php
+++ b/src/Container/ServiceExtensions.php
@@ -15,10 +15,8 @@ class ServiceExtensions
     private const SERVICE_TYPE_CHANGED = 2;
     private const SERVICE_TYPE_NOT_OBJECT = 0;
 
-    /**
-     * @var array<string, list<ExtendingService>>
-     */
-    protected $extensions = [];
+    /** @var array<string, list<ExtendingService>> */
+    protected array $extensions = [];
 
     /**
      * @param string $type
@@ -87,6 +85,9 @@ class ServiceExtensions
      * @param Container $container
      * @param array $extendedClasses
      * @return mixed
+     *
+     * phpcs:disable Generic.Metrics.CyclomaticComplexity
+     * phpcs:disable Inpsyde.CodeQuality.ReturnTypeDeclaration
      */
     protected function resolveByType(
         string $className,
@@ -94,6 +95,8 @@ class ServiceExtensions
         Container $container,
         array $extendedClasses = []
     ) {
+        // phpcs:enable Generic.Metrics.CyclomaticComplexity
+        // phpcs:enable Inpsyde.CodeQuality.ReturnTypeDeclaration
 
         $extendedClasses[] = $className;
 
@@ -102,20 +105,28 @@ class ServiceExtensions
 
         // 1st group of extensions: targeting exact class
         $byClass = $this->extensions[self::typeId($className)] ?? null;
-        $byClass and $allCallbacks[$className] = $byClass;
+        if (($byClass !== null) && ($byClass !== [])) {
+            $allCallbacks[$className] = $byClass;
+        }
 
         // 2nd group of extensions: targeting parent classes
-        /** @var class-string $parentName */
-        foreach (class_parents($service, false) ?: [] as $parentName) {
+        $parents = class_parents($service, false);
+        ($parents === false) and $parents = [];
+        foreach ($parents as $parentName) {
             $byParent = $this->extensions[self::typeId($parentName)] ?? null;
-            $byParent and $allCallbacks[$parentName] = $byParent;
+            if (($byParent !== null) && ($byParent !== [])) {
+                $allCallbacks[$parentName] = $byParent;
+            }
         }
 
         // 3rd group of extensions: targeting implemented interfaces
-        /** @var class-string $interfaceName */
-        foreach (class_implements($service, false) ?: [] as $interfaceName) {
+        $interfaces = class_implements($service, false);
+        ($interfaces === false) and $interfaces = [];
+        foreach ($interfaces as $interfaceName) {
             $byInterface = $this->extensions[self::typeId($interfaceName)] ?? null;
-            $byInterface and $allCallbacks[$interfaceName] = $byInterface;
+            if (($byInterface !== null) && ($byInterface !== [])) {
+                $allCallbacks[$interfaceName] = $byInterface;
+            }
         }
 
         $resultType = self::SERVICE_TYPE_NOT_CHANGED;
@@ -126,6 +137,7 @@ class ServiceExtensions
             if (($resultType === self::SERVICE_TYPE_CHANGED) && !is_a($service, $type)) {
                 continue;
             }
+            /** @var object $service */
             [$service, $resultType] = $this->extendByType($type, $service, $container, $extenders);
             if ($resultType === self::SERVICE_TYPE_NOT_OBJECT) {
                 // Service is not an object anymore, let's return it.
@@ -151,7 +163,7 @@ class ServiceExtensions
      * @param object $service
      * @param Container $container
      * @param list<ExtendingService> $extenders
-     * @return array{mixed, int}
+     * @return list{mixed, int}
      */
     private function extendByType(
         string $type,

--- a/src/Module/ExecutableModule.php
+++ b/src/Module/ExecutableModule.php
@@ -8,7 +8,6 @@ use Psr\Container\ContainerInterface;
 
 interface ExecutableModule extends Module
 {
-
     /**
      * Perform actions with objects retrieved from the container. Usually, adding WordPress hooks.
      * Return true to signal a success, false to signal a failure.

--- a/src/Module/ExtendingModule.php
+++ b/src/Module/ExtendingModule.php
@@ -11,7 +11,6 @@ use Psr\Container\ContainerInterface;
  */
 interface ExtendingModule extends Module
 {
-
     /**
      * Return application services' extensions.
      *

--- a/src/Module/Module.php
+++ b/src/Module/Module.php
@@ -9,12 +9,10 @@ namespace Inpsyde\Modularity\Module;
  */
 interface Module
 {
-
     /**
      * Unique identifier for your Module.
      *
      * @return string
      */
     public function id(): string;
-
 }

--- a/src/Module/ModuleClassNameIdTrait.php
+++ b/src/Module/ModuleClassNameIdTrait.php
@@ -4,16 +4,11 @@ declare(strict_types=1);
 
 namespace Inpsyde\Modularity\Module;
 
-/**
- * Trait ModuleClassNameIdTrait
- *
- * @package Inpsyde\Modularity\Module
- */
 trait ModuleClassNameIdTrait
 {
-
     /**
      * @return string
+     *
      * @see Module::id()
      */
     public function id(): string

--- a/src/Module/ServiceModule.php
+++ b/src/Module/ServiceModule.php
@@ -11,7 +11,6 @@ use Psr\Container\ContainerInterface;
  */
 interface ServiceModule extends Module
 {
-
     /**
      * Return application services' factories.
      *

--- a/src/Properties/BaseProperties.php
+++ b/src/Properties/BaseProperties.php
@@ -6,30 +6,11 @@ namespace Inpsyde\Modularity\Properties;
 
 class BaseProperties implements Properties
 {
-    /**
-     * @var null|bool
-     */
-    protected $isDebug = null;
-
-    /**
-     * @var string
-     */
-    protected $baseName;
-
-    /**
-     * @var string
-     */
-    protected $basePath;
-
-    /**
-     * @var string|null
-     */
-    protected $baseUrl;
-
-    /**
-     * @var array
-     */
-    protected $properties;
+    protected ?bool $isDebug = null;
+    protected string $baseName;
+    protected string $basePath;
+    protected ?string $baseUrl;
+    protected array $properties;
 
     /**
      * @param string $baseName
@@ -43,10 +24,11 @@ class BaseProperties implements Properties
         string $baseUrl = null,
         array $properties = []
     ) {
+
         $baseName = $this->sanitizeBaseName($baseName);
-        $basePath = (string) trailingslashit($basePath);
-        if ($baseUrl) {
-            $baseUrl = (string) trailingslashit($baseUrl);
+        $basePath = trailingslashit($basePath);
+        if ($baseUrl !== null) {
+            $baseUrl = trailingslashit($baseUrl);
         }
 
         $this->baseName = $baseName;
@@ -57,8 +39,7 @@ class BaseProperties implements Properties
 
     /**
      * @param string $name
-     *
-     * @return string
+     * @return lowercase-string
      */
     protected function sanitizeBaseName(string $name): string
     {
@@ -162,7 +143,7 @@ class BaseProperties implements Properties
     {
         $value = $this->get(self::PROP_REQUIRES_WP);
 
-        return $value && is_string($value) ? $value : null;
+        return (($value !== '') && is_string($value)) ? $value : null;
     }
 
     /**
@@ -172,7 +153,7 @@ class BaseProperties implements Properties
     {
         $value = $this->get(self::PROP_REQUIRES_PHP);
 
-        return $value && is_string($value) ? $value : null;
+        return (($value !== '') && is_string($value)) ? $value : null;
     }
 
     /**
@@ -185,7 +166,7 @@ class BaseProperties implements Properties
 
     /**
      * @param string $key
-     * @param null $default
+     * @param mixed $default
      * @return mixed
      */
     public function get(string $key, $default = null)
@@ -209,6 +190,7 @@ class BaseProperties implements Properties
     public function isDebug(): bool
     {
         if ($this->isDebug === null) {
+            /** @psalm-suppress TypeDoesNotContainType */
             $this->isDebug = defined('WP_DEBUG') && WP_DEBUG;
         }
 

--- a/src/Properties/PluginProperties.php
+++ b/src/Properties/PluginProperties.php
@@ -4,25 +4,14 @@ declare(strict_types=1);
 
 namespace Inpsyde\Modularity\Properties;
 
-/**
- * Class PluginProperties
- *
- * @package Inpsyde\Modularity\Properties
- *
- * @psalm-suppress PossiblyFalseArgument, InvalidArgument
- */
 class PluginProperties extends BaseProperties
 {
-    /**
-     * Custom properties for Plugins.
-     */
+    // Custom properties for Plugins
     public const PROP_NETWORK = 'network';
     public const PROP_REQUIRES_PLUGINS = 'requiresPlugins';
+
     /**
-     * Available methods of Properties::__call()
-     * from plugin headers.
-     *
-     * @link https://developer.wordpress.org/reference/functions/get_plugin_data/
+     * @see https://developer.wordpress.org/reference/functions/get_plugin_data/
      */
     protected const HEADERS = [
         self::PROP_AUTHOR => 'Author',
@@ -41,34 +30,14 @@ class PluginProperties extends BaseProperties
         self::PROP_REQUIRES_PLUGINS => 'RequiresPlugins',
     ];
 
-    /**
-     * @var string
-     */
-    private $pluginMainFile;
-
-    /**
-     * @var string
-     */
-    private $pluginBaseName;
-
-    /**
-     * @var bool|null
-     */
-    protected $isMu;
-
-    /**
-     * @var bool|null
-     */
-    protected $isActive;
-
-    /**
-     * @var bool|null
-     */
-    protected $isNetworkActive;
+    private string $pluginMainFile;
+    private string $pluginBaseName;
+    protected ?bool $isMu = null;
+    protected ?bool $isActive = null;
+    protected ?bool $isNetworkActive = null;
 
     /**
      * @param string $pluginMainFile
-     *
      * @return PluginProperties
      */
     public static function new(string $pluginMainFile): PluginProperties
@@ -77,8 +46,6 @@ class PluginProperties extends BaseProperties
     }
 
     /**
-     * PluginProperties constructor.
-     *
      * @param string $pluginMainFile
      */
     protected function __construct(string $pluginMainFile)
@@ -87,9 +54,10 @@ class PluginProperties extends BaseProperties
             require_once ABSPATH . 'wp-admin/includes/plugin.php';
         }
 
-        // $markup = false, to avoid an incorrect early wptexturize call. Also we probably don't want HTML here anyway
+        // $markup = false, to avoid an incorrect early wptexturize call.
+        // We also probably don't want HTML here anyway
         // @see https://core.trac.wordpress.org/ticket/49965
-        $pluginData = get_plugin_data($pluginMainFile, false);
+        $pluginData = (array) get_plugin_data($pluginMainFile, false);
         $properties = Properties::DEFAULT_PROPERTIES;
 
         // Map pluginData to internal structure.
@@ -123,8 +91,6 @@ class PluginProperties extends BaseProperties
 
     /**
      * @return bool
-     *
-     * @psalm-suppress PossiblyFalseArgument
      */
     public function network(): bool
     {
@@ -177,10 +143,6 @@ class PluginProperties extends BaseProperties
     public function isMuPlugin(): bool
     {
         if ($this->isMu === null) {
-            /**
-             * @psalm-suppress UndefinedConstant
-             * @psalm-suppress MixedArgument
-             */
             $muPluginDir = wp_normalize_path(WPMU_PLUGIN_DIR);
             $this->isMu = strpos($this->pluginMainFile, $muPluginDir) === 0;
         }

--- a/src/Properties/Properties.php
+++ b/src/Properties/Properties.php
@@ -17,9 +17,7 @@ interface Properties
     public const PROP_REQUIRES_WP = 'requiresWp';
     public const PROP_REQUIRES_PHP = 'requiresPhp';
     public const PROP_TAGS = 'tags';
-    /**
-     * @var array
-     */
+
     public const DEFAULT_PROPERTIES = [
         self::PROP_AUTHOR => '',
         self::PROP_AUTHOR_URI => '',
@@ -36,15 +34,13 @@ interface Properties
 
     /**
      * @param string $key
-     * @param null $default
-     *
+     * @param mixed $default
      * @return mixed
      */
     public function get(string $key, $default = null);
 
     /**
      * @param string $key
-     *
      * @return bool
      */
     public function has(string $key): bool;
@@ -103,6 +99,7 @@ interface Properties
 
     /**
      * The home page of the plugin, theme or library.
+     *
      * @return string
      */
     public function uri(): string;
@@ -130,10 +127,10 @@ interface Properties
      * Optional. Currently, only available for Theme and Library.
      * Plugins do not have support for "tags"/"keywords" in header.
      *
-     * @link https://developer.wordpress.org/reference/classes/wp_theme/#properties
-     * @link https://getcomposer.org/doc/04-schema.md#keywords
-     *
      * @return array
+     *
+     * @see https://developer.wordpress.org/reference/classes/wp_theme/#properties
+     * @see https://getcomposer.org/doc/04-schema.md#keywords
      */
     public function tags(): array;
 }

--- a/src/Properties/ThemeProperties.php
+++ b/src/Properties/ThemeProperties.php
@@ -4,26 +4,12 @@ declare(strict_types=1);
 
 namespace Inpsyde\Modularity\Properties;
 
-/**
- * Class ThemeProperties
- *
- * @package Inpsyde\Modularity\Properties
- *
- * @psalm-suppress PossiblyFalseArgument, InvalidArgument
- */
 class ThemeProperties extends BaseProperties
 {
-    /**
-     * Additional properties specific for themes.
-     */
     public const PROP_STATUS = 'status';
     public const PROP_TEMPLATE = 'template';
-    /**
-     * Available methods of Properties::__call()
-     * from theme headers.
-     *
-     * @link https://developer.wordpress.org/reference/classes/wp_theme/
-     */
+
+    /** @see https://developer.wordpress.org/reference/classes/wp_theme/ */
     protected const HEADERS = [
         self::PROP_AUTHOR => 'Author',
         self::PROP_AUTHOR_URI => 'AuthorURI',
@@ -53,8 +39,6 @@ class ThemeProperties extends BaseProperties
     }
 
     /**
-     * ThemeProperties constructor.
-     *
      * @param string $themeDirectory
      */
     protected function __construct(string $themeDirectory)
@@ -67,13 +51,15 @@ class ThemeProperties extends BaseProperties
         $properties = Properties::DEFAULT_PROPERTIES;
 
         foreach (self::HEADERS as $key => $themeKey) {
-            /** @psalm-suppress DocblockTypeContradiction */
-            $properties[$key] = $theme->get($themeKey) ?? '';
+            $property = $theme->get($themeKey);
+            if (is_string($property) || is_array($property)) {
+                $properties[$key] = $property;
+            }
         }
 
         $baseName = $theme->get_stylesheet();
         $basePath = $theme->get_stylesheet_directory();
-        $baseUrl = (string) trailingslashit($theme->get_stylesheet_directory_uri());
+        $baseUrl = trailingslashit($theme->get_stylesheet_directory_uri());
 
         parent::__construct(
             $baseName,
@@ -84,8 +70,6 @@ class ThemeProperties extends BaseProperties
     }
 
     /**
-     * If the theme is published.
-     *
      * @return string
      */
     public function status(): string
@@ -93,6 +77,9 @@ class ThemeProperties extends BaseProperties
         return (string) $this->get(self::PROP_STATUS);
     }
 
+    /**
+     * @return string
+     */
     public function template(): string
     {
         return (string) $this->get(self::PROP_TEMPLATE);
@@ -120,7 +107,7 @@ class ThemeProperties extends BaseProperties
     public function parentThemeProperties(): ?ThemeProperties
     {
         $template = $this->template();
-        if (!$template) {
+        if ($template === '') {
             return null;
         }
 

--- a/tests/boot.php
+++ b/tests/boot.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+// phpcs:disable PSR1
+
 $testsDir = str_replace('\\', '/', __DIR__);
 $libDir = dirname($testsDir);
 $vendorDir = "{$libDir}/vendor";
@@ -22,7 +26,10 @@ if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
     require_once $autoload;
 }
 
-defined('ABSPATH') or define('ABSPATH', "{$vendorDir}/johnpbloch/wordpress-core/");
-require_once "{$vendorDir}/johnpbloch/wordpress-core/wp-includes/class-wp-error.php";
+if (!defined('ABSPATH')) {
+    define('ABSPATH', "{$vendorDir}/roots/wordpress-no-content/");
+}
+
+require_once "{$vendorDir}/roots/wordpress-no-content/wp-includes/class-wp-error.php";
 
 unset($testsDir, $libDir, $vendorDir, $autoload);

--- a/tests/unit/Container/ContainerConfiguratorTest.php
+++ b/tests/unit/Container/ContainerConfiguratorTest.php
@@ -385,7 +385,7 @@ class ContainerConfiguratorTest extends TestCase
         class A {}
         class B extends A {}
         PHP;
-        eval($php); // phpcs:ignore
+        eval($php);
 
         $called = [];
 
@@ -446,7 +446,7 @@ class ContainerConfiguratorTest extends TestCase
         class D {};
         class E extends D {};
         PHP;
-        eval($php); // phpcs:ignore
+        eval($php);
 
         $configurator->addExtension(
             '@instanceof<D>',

--- a/tests/unit/Container/PackageProxyContainerTest.php
+++ b/tests/unit/Container/PackageProxyContainerTest.php
@@ -16,7 +16,7 @@ class PackageProxyContainerTest extends TestCase
      */
     public function testAccessingContainerEarlyThrows(): void
     {
-        $package = Package::new($this->mockProperties());
+        $package = Package::new($this->stubProperties());
 
         $container = new PackageProxyContainer($package);
         static::assertFalse($container->has('test'));
@@ -30,7 +30,7 @@ class PackageProxyContainerTest extends TestCase
      */
     public function testAccessingFailedPackageEarlyThrows(): void
     {
-        $package = Package::new($this->mockProperties());
+        $package = Package::new($this->stubProperties());
 
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_INIT))
             ->once()

--- a/tests/unit/Container/ServiceExtensionsTest.php
+++ b/tests/unit/Container/ServiceExtensionsTest.php
@@ -6,8 +6,6 @@ namespace Inpsyde\Modularity\Tests\Unit\Container;
 
 use Inpsyde\Modularity\Container\ServiceExtensions;
 use Inpsyde\Modularity\Tests\TestCase;
-use Psr\Container\ContainerInterface;
-use Psr\Container\NotFoundExceptionInterface;
 
 class ServiceExtensionsTest extends TestCase
 {
@@ -73,26 +71,5 @@ class ServiceExtensionsTest extends TestCase
         static::assertTrue($serviceExtensions->has('thing'));
         static::assertTrue($serviceExtensions->has(ServiceExtensions::typeId(\stdClass::class)));
         static::assertSame($expected, $thing->count);
-    }
-
-    /**
-     * @return ContainerInterface
-     */
-    private function stubContainer(): ContainerInterface
-    {
-        return new class implements ContainerInterface
-        {
-            public function get(string $id)
-            {
-                throw new class () extends \Exception implements NotFoundExceptionInterface
-                {
-                };
-            }
-
-            public function has(string $id): bool
-            {
-                return false;
-            }
-        };
     }
 }

--- a/tests/unit/Module/ModuleClassNameIdTraitTest.php
+++ b/tests/unit/Module/ModuleClassNameIdTraitTest.php
@@ -9,14 +9,13 @@ use Inpsyde\Modularity\Tests\TestCase;
 
 class ModuleClassNameIdTraitTest extends TestCase
 {
-
     /**
      * @test
      */
     public function testIdMatchesClassName(): void
     {
-        $module = new class implements Modularity\Module\Module {
-
+        $module = new class implements Modularity\Module\Module
+        {
             use Modularity\Module\ModuleClassNameIdTrait;
         };
 

--- a/tests/unit/PackageTest.php
+++ b/tests/unit/PackageTest.php
@@ -22,7 +22,7 @@ class PackageTest extends TestCase
     public function testBasic(): void
     {
         $expectedName = 'foo';
-        $propertiesStub = $this->mockProperties($expectedName);
+        $propertiesStub = $this->stubProperties($expectedName);
 
         $package = Package::new($propertiesStub);
 
@@ -36,16 +36,16 @@ class PackageTest extends TestCase
     }
 
     /**
+     * @test
+     * @dataProvider provideHookNameSuffix
+     *
      * @param string $suffix
      * @param string $baseName
      * @param string $expectedHookName
-     *
-     * @test
-     * @dataProvider provideHookNameSuffix
      */
     public function testHookName(string $suffix, string $baseName, string $expectedHookName): void
     {
-        $propertiesStub = $this->mockProperties($baseName);
+        $propertiesStub = $this->stubProperties($baseName);
         $package = Package::new($propertiesStub);
         static::assertSame($expectedHookName, $package->hookName($suffix));
     }
@@ -53,7 +53,7 @@ class PackageTest extends TestCase
     /**
      * @return \Generator
      */
-    public function provideHookNameSuffix(): \Generator
+    public static function provideHookNameSuffix(): \Generator
     {
         $expectedName = 'baseName';
         $baseHookName = 'inpsyde.modularity.' . $expectedName;
@@ -89,8 +89,8 @@ class PackageTest extends TestCase
     {
         $expectedId = 'my-module';
 
-        $moduleStub = $this->mockModule($expectedId);
-        $propertiesStub = $this->mockProperties('name', false);
+        $moduleStub = $this->stubModule($expectedId);
+        $propertiesStub = $this->stubProperties('name', false);
 
         $package = Package::new($propertiesStub)->addModule($moduleStub);
 
@@ -101,7 +101,7 @@ class PackageTest extends TestCase
         static::assertFalse($package->moduleIs($expectedId, Package::MODULE_EXTENDED));
         static::assertFalse($package->moduleIs($expectedId, Package::MODULE_ADDED));
 
-        // booting again will do nothing.
+        // booting again fails, but does not throw because debug is false
         static::assertFalse($package->boot());
     }
 
@@ -113,10 +113,10 @@ class PackageTest extends TestCase
         $moduleId = 'my-service-module';
         $serviceId = 'service-id';
 
-        $module = $this->mockModule($moduleId, ServiceModule::class);
+        $module = $this->stubModule($moduleId, ServiceModule::class);
         $module->expects('services')->andReturn($this->stubServices($serviceId));
 
-        $package = Package::new($this->mockProperties())->addModule($module);
+        $package = Package::new($this->stubProperties())->addModule($module);
 
         static::assertTrue($package->boot());
         static::assertFalse($package->moduleIs($moduleId, Package::MODULE_NOT_ADDED));
@@ -135,10 +135,10 @@ class PackageTest extends TestCase
         $moduleId = 'my-factory-module';
         $factoryId = 'factory-id';
 
-        $module = $this->mockModule($moduleId, FactoryModule::class);
+        $module = $this->stubModule($moduleId, FactoryModule::class);
         $module->expects('factories')->andReturn($this->stubServices($factoryId));
 
-        $package = Package::new($this->mockProperties())->addModule($module);
+        $package = Package::new($this->stubProperties())->addModule($module);
 
         static::assertTrue($package->boot());
         static::assertFalse($package->moduleIs($moduleId, Package::MODULE_NOT_ADDED));
@@ -157,10 +157,10 @@ class PackageTest extends TestCase
         $moduleId = 'my-extension-module';
         $extensionId = 'extension-id';
 
-        $module = $this->mockModule($moduleId, ExtendingModule::class);
+        $module = $this->stubModule($moduleId, ExtendingModule::class);
         $module->expects('extensions')->andReturn($this->stubServices($extensionId));
 
-        $package = Package::new($this->mockProperties())->addModule($module);
+        $package = Package::new($this->stubProperties())->addModule($module);
 
         static::assertTrue($package->boot());
         static::assertFalse($package->moduleIs($moduleId, Package::MODULE_NOT_ADDED));
@@ -180,11 +180,11 @@ class PackageTest extends TestCase
         $moduleId = 'my-extension-module';
         $serviceId = 'service-id';
 
-        $module = $this->mockModule($moduleId, ServiceModule::class, ExtendingModule::class);
+        $module = $this->stubModule($moduleId, ServiceModule::class, ExtendingModule::class);
         $module->expects('services')->andReturn($this->stubServices($serviceId));
         $module->expects('extensions')->andReturn($this->stubServices($serviceId));
 
-        $package = Package::new($this->mockProperties())->addModule($module);
+        $package = Package::new($this->stubProperties())->addModule($module);
 
         static::assertTrue($package->boot());
         static::assertFalse($package->moduleIs($moduleId, Package::MODULE_NOT_ADDED));
@@ -201,10 +201,10 @@ class PackageTest extends TestCase
     public function testBootWithExecutableModule(): void
     {
         $moduleId = 'executable-module';
-        $module = $this->mockModule($moduleId, ExecutableModule::class);
+        $module = $this->stubModule($moduleId, ExecutableModule::class);
         $module->expects('run')->andReturn(true);
 
-        $package = Package::new($this->mockProperties())->addModule($module);
+        $package = Package::new($this->stubProperties())->addModule($module);
 
         static::assertTrue($package->boot());
         static::assertTrue($package->moduleIs($moduleId, Package::MODULE_ADDED));
@@ -220,10 +220,10 @@ class PackageTest extends TestCase
     public function testBootWithExecutableModuleFailed(): void
     {
         $moduleId = 'executable-module';
-        $module = $this->mockModule($moduleId, ExecutableModule::class);
+        $module = $this->stubModule($moduleId, ExecutableModule::class);
         $module->expects('run')->andReturn(false);
 
-        $package = Package::new($this->mockProperties())->addModule($module);
+        $package = Package::new($this->stubProperties())->addModule($module);
 
         static::assertTrue($package->boot());
         static::assertTrue($package->moduleIs($moduleId, Package::MODULE_ADDED));
@@ -237,10 +237,10 @@ class PackageTest extends TestCase
      */
     public function testBootPassingModulesEmitDeprecation(): void
     {
-        $module1 = $this->mockModule('module_1', ServiceModule::class);
+        $module1 = $this->stubModule('module_1', ServiceModule::class);
         $module1->allows('services')->andReturn($this->stubServices('service_1'));
 
-        $package = Package::new($this->mockProperties('test', true));
+        $package = Package::new($this->stubProperties('test', true));
 
         $this->convertDeprecationsToExceptions();
         try {
@@ -259,11 +259,11 @@ class PackageTest extends TestCase
      */
     public function testAddModuleFailsAfterBuild(): void
     {
-        $package = Package::new($this->mockProperties('test', true))->build();
+        $package = Package::new($this->stubProperties('test', true))->build();
 
         $this->expectExceptionMessageMatches("/can't add module/i");
 
-        $package->addModule($this->mockModule());
+        $package->addModule($this->stubModule());
     }
 
     /**
@@ -271,7 +271,7 @@ class PackageTest extends TestCase
      */
     public function testPropertiesCanBeRetrievedFromContainer(): void
     {
-        $expected = $this->mockProperties();
+        $expected = $this->stubProperties();
         $actual = Package::new($expected)->build()->container()->get(Package::PROPERTIES);
 
         static::assertSame($expected, $actual);
@@ -284,21 +284,21 @@ class PackageTest extends TestCase
      */
     public function testStatusForMultipleModulesWhenDebug(): void
     {
-        $emptyModule = $this->mockModule('empty');
-        $emptyServicesModule = $this->mockModule('empty_services', ServiceModule::class);
-        $emptyFactoriesModule = $this->mockModule('empty_factories', FactoryModule::class);
-        $emptyExtensionsModule = $this->mockModule('empty_extensions', ExtendingModule::class);
+        $emptyModule = $this->stubModule('empty');
+        $emptyServicesModule = $this->stubModule('empty_services', ServiceModule::class);
+        $emptyFactoriesModule = $this->stubModule('empty_factories', FactoryModule::class);
+        $emptyExtensionsModule = $this->stubModule('empty_extensions', ExtendingModule::class);
 
-        $servicesModule = $this->mockModule('service', ServiceModule::class);
+        $servicesModule = $this->stubModule('service', ServiceModule::class);
         $servicesModule->expects('services')->andReturn($this->stubServices('S1', 'S2'));
 
-        $factoriesModule = $this->mockModule('factory', FactoryModule::class);
+        $factoriesModule = $this->stubModule('factory', FactoryModule::class);
         $factoriesModule->expects('factories')->andReturn($this->stubServices('F'));
 
-        $extendingModule = $this->mockModule('extension', ExtendingModule::class);
+        $extendingModule = $this->stubModule('extension', ExtendingModule::class);
         $extendingModule->expects('extensions')->andReturn($this->stubServices('E'));
 
-        $multiModule = $this->mockModule(
+        $multiModule = $this->stubModule(
             'multi',
             ServiceModule::class,
             ExtendingModule::class,
@@ -308,7 +308,7 @@ class PackageTest extends TestCase
         $multiModule->expects('factories')->andReturn($this->stubServices('MF1', 'MF2'));
         $multiModule->expects('extensions')->andReturn($this->stubServices('ME1', 'ME2'));
 
-        $package = Package::new($this->mockProperties('name', true))
+        $package = Package::new($this->stubProperties('name', true))
             ->addModule($emptyModule)
             ->addModule($extendingModule)
             ->addModule($emptyServicesModule)
@@ -378,21 +378,21 @@ class PackageTest extends TestCase
      */
     public function testStatusForMultipleModulesWhenNotDebug(): void
     {
-        $emptyModule = $this->mockModule('empty');
-        $emptyServicesModule = $this->mockModule('empty_services', ServiceModule::class);
-        $emptyFactoriesModule = $this->mockModule('empty_factories', FactoryModule::class);
-        $emptyExtensionsModule = $this->mockModule('empty_extensions', ExtendingModule::class);
+        $emptyModule = $this->stubModule('empty');
+        $emptyServicesModule = $this->stubModule('empty_services', ServiceModule::class);
+        $emptyFactoriesModule = $this->stubModule('empty_factories', FactoryModule::class);
+        $emptyExtensionsModule = $this->stubModule('empty_extensions', ExtendingModule::class);
 
-        $servicesModule = $this->mockModule('service', ServiceModule::class);
+        $servicesModule = $this->stubModule('service', ServiceModule::class);
         $servicesModule->expects('services')->andReturn($this->stubServices('S1', 'S2'));
 
-        $factoriesModule = $this->mockModule('factory', FactoryModule::class);
+        $factoriesModule = $this->stubModule('factory', FactoryModule::class);
         $factoriesModule->expects('factories')->andReturn($this->stubServices('F'));
 
-        $extendingModule = $this->mockModule('extension', ExtendingModule::class);
+        $extendingModule = $this->stubModule('extension', ExtendingModule::class);
         $extendingModule->expects('extensions')->andReturn($this->stubServices('E'));
 
-        $multiModule = $this->mockModule(
+        $multiModule = $this->stubModule(
             'multi',
             ServiceModule::class,
             ExtendingModule::class,
@@ -402,7 +402,7 @@ class PackageTest extends TestCase
         $multiModule->expects('factories')->andReturn($this->stubServices('MF1', 'MF2'));
         $multiModule->expects('extensions')->andReturn($this->stubServices('ME1', 'ME2'));
 
-        $package = Package::new($this->mockProperties('name', false))
+        $package = Package::new($this->stubProperties('name', false))
             ->addModule($emptyModule)
             ->addModule($extendingModule)
             ->addModule($emptyServicesModule)
@@ -472,14 +472,14 @@ class PackageTest extends TestCase
      */
     public function testPackageConnection(): void
     {
-        $module1 = $this->mockModule('module_1', ServiceModule::class);
+        $module1 = $this->stubModule('module_1', ServiceModule::class);
         $module1->expects('services')->andReturn($this->stubServices('service_1'));
-        $package1 = Package::new($this->mockProperties('package_1', false))
+        $package1 = Package::new($this->stubProperties('package_1', false))
             ->addModule($module1);
 
-        $module2 = $this->mockModule('module_2', ServiceModule::class);
+        $module2 = $this->stubModule('module_2', ServiceModule::class);
         $module2->expects('services')->andReturn($this->stubServices('service_2'));
-        $package2 = Package::new($this->mockProperties('package_2', false))
+        $package2 = Package::new($this->stubProperties('package_2', false))
             ->addModule($module2);
 
         Monkey\Actions\expectDone($package2->hookName(Package::ACTION_PACKAGE_CONNECTED))
@@ -504,14 +504,14 @@ class PackageTest extends TestCase
      */
     public function testPackageConnectionFailsIfBootedWithDebugOff(): void
     {
-        $module1 = $this->mockModule('module_1', ServiceModule::class);
+        $module1 = $this->stubModule('module_1', ServiceModule::class);
         $module1->expects('services')->andReturn($this->stubServices('service_1'));
-        $package1 = Package::new($this->mockProperties('package_1', false))
+        $package1 = Package::new($this->stubProperties('package_1', false))
             ->addModule($module1);
 
-        $module2 = $this->mockModule('module_2', ServiceModule::class);
+        $module2 = $this->stubModule('module_2', ServiceModule::class);
         $module2->expects('services')->andReturn($this->stubServices('service_2'));
-        $package2 = Package::new($this->mockProperties('package_2', false))
+        $package2 = Package::new($this->stubProperties('package_2', false))
             ->addModule($module2);
 
         $package1->boot();
@@ -542,14 +542,14 @@ class PackageTest extends TestCase
      */
     public function testPackageConnectionFailsIfBootedWithDebugOn(): void
     {
-        $module1 = $this->mockModule('module_1', ServiceModule::class);
+        $module1 = $this->stubModule('module_1', ServiceModule::class);
         $module1->expects('services')->andReturn($this->stubServices('service_1'));
-        $package1 = Package::new($this->mockProperties('package_1', true))
+        $package1 = Package::new($this->stubProperties('package_1', true))
             ->addModule($module1);
 
-        $module2 = $this->mockModule('module_2', ServiceModule::class);
+        $module2 = $this->stubModule('module_2', ServiceModule::class);
         $module2->expects('services')->andReturn($this->stubServices('service_2'));
-        $package2 = Package::new($this->mockProperties('package_2', true))
+        $package2 = Package::new($this->stubProperties('package_2', true))
             ->addModule($module2);
 
         $package1->boot();
@@ -562,7 +562,7 @@ class PackageTest extends TestCase
         Monkey\Actions\expectDone($package2->hookName(Package::ACTION_FAILED_BUILD))
             ->once()
             ->whenHappen(
-                function (\Throwable $throwable) {
+                function (\Throwable $throwable): void {
                     $this->assertThrowableMessageMatches($throwable, 'failed connect.+?booted');
                 }
             );
@@ -578,14 +578,14 @@ class PackageTest extends TestCase
      */
     public function testPackageConnectionWithProxyContainer(): void
     {
-        $module1 = $this->mockModule('module_1', ServiceModule::class);
+        $module1 = $this->stubModule('module_1', ServiceModule::class);
         $module1->expects('services')->andReturn($this->stubServices('service_1'));
-        $package1 = Package::new($this->mockProperties('package_1', false))
+        $package1 = Package::new($this->stubProperties('package_1', false))
             ->addModule($module1);
 
-        $module2 = $this->mockModule('module_2', ServiceModule::class);
+        $module2 = $this->stubModule('module_2', ServiceModule::class);
         $module2->expects('services')->andReturn($this->stubServices('service_2'));
-        $package2 = Package::new($this->mockProperties('package_2', false))
+        $package2 = Package::new($this->stubProperties('package_2', false))
             ->addModule($module2);
 
         $connected = $package2->connect($package1);
@@ -615,14 +615,14 @@ class PackageTest extends TestCase
      */
     public function testPackageConnectionWithProxyContainerFailsIfNoBoot(): void
     {
-        $module1 = $this->mockModule('module_1', ServiceModule::class);
+        $module1 = $this->stubModule('module_1', ServiceModule::class);
         $module1->expects('services')->andReturn($this->stubServices('service_1'));
-        $package1 = Package::new($this->mockProperties('package_1', false))
+        $package1 = Package::new($this->stubProperties('package_1', false))
             ->addModule($module1);
 
-        $module2 = $this->mockModule('module_2', ServiceModule::class);
+        $module2 = $this->stubModule('module_2', ServiceModule::class);
         $module2->expects('services')->andReturn($this->stubServices('service_2'));
-        $package2 = Package::new($this->mockProperties('package_2', false))
+        $package2 = Package::new($this->stubProperties('package_2', false))
             ->addModule($module2);
 
         $connected = $package2->connect($package1);
@@ -644,14 +644,14 @@ class PackageTest extends TestCase
      */
     public function testPackageCanOnlyBeConnectedOnceDebugOff(): void
     {
-        $module1 = $this->mockModule('module_1', ServiceModule::class);
+        $module1 = $this->stubModule('module_1', ServiceModule::class);
         $module1->expects('services')->andReturn($this->stubServices('service_1'));
-        $package1 = Package::new($this->mockProperties('package_1', false))
+        $package1 = Package::new($this->stubProperties('package_1', false))
             ->addModule($module1);
 
-        $module2 = $this->mockModule('module_2', ServiceModule::class);
+        $module2 = $this->stubModule('module_2', ServiceModule::class);
         $module2->expects('services')->andReturn($this->stubServices('service_2'));
-        $package2 = Package::new($this->mockProperties('package_2', false))
+        $package2 = Package::new($this->stubProperties('package_2', false))
             ->addModule($module2);
 
         Monkey\Actions\expectDone($package2->hookName(Package::ACTION_PACKAGE_CONNECTED))
@@ -686,14 +686,14 @@ class PackageTest extends TestCase
      */
     public function testPackageCanOnlyBeConnectedOnceDebugOn(): void
     {
-        $module1 = $this->mockModule('module_1', ServiceModule::class);
+        $module1 = $this->stubModule('module_1', ServiceModule::class);
         $module1->expects('services')->andReturn($this->stubServices('service_1'));
-        $package1 = Package::new($this->mockProperties('package_1', false))
+        $package1 = Package::new($this->stubProperties('package_1', false))
             ->addModule($module1);
 
-        $module2 = $this->mockModule('module_2', ServiceModule::class);
+        $module2 = $this->stubModule('module_2', ServiceModule::class);
         $module2->expects('services')->andReturn($this->stubServices('service_2'));
-        $package2 = Package::new($this->mockProperties('package_2', true))
+        $package2 = Package::new($this->stubProperties('package_2', true))
             ->addModule($module2);
 
         Monkey\Actions\expectDone($package2->hookName(Package::ACTION_PACKAGE_CONNECTED))
@@ -706,7 +706,7 @@ class PackageTest extends TestCase
         Monkey\Actions\expectDone($package2->hookName(Package::ACTION_FAILED_BUILD))
             ->once()
             ->whenHappen(
-                function (\Throwable $throwable) {
+                function (\Throwable $throwable): void {
                     $this->assertThrowableMessageMatches($throwable, 'failed connect.+?already');
                 }
             );
@@ -724,9 +724,9 @@ class PackageTest extends TestCase
      */
     public function testPackageCanNotBeConnectedWithThemselves(): void
     {
-        $module1 = $this->mockModule('module_1', ServiceModule::class);
+        $module1 = $this->stubModule('module_1', ServiceModule::class);
         $module1->expects('services')->andReturn($this->stubServices('service_1'));
-        $package1 = Package::new($this->mockProperties('package_1', true))
+        $package1 = Package::new($this->stubProperties('package_1', true))
             ->addModule($module1);
 
         $action = $package1->hookName(Package::ACTION_FAILED_CONNECTION);
@@ -737,10 +737,13 @@ class PackageTest extends TestCase
 
     /**
      * @test
+     *
+     * phpcs:disable Inpsyde.CodeQuality.NestingLevel
      */
     public function testBuildResolveServices(): void
     {
-        $module = new class() implements ServiceModule, ExtendingModule, ExecutableModule
+        // phpcs:enable phpcs:disable Inpsyde.CodeQuality.NestingLevel
+        $module = new class () implements ServiceModule, ExtendingModule, ExecutableModule
         {
             public function id(): string
             {
@@ -750,23 +753,27 @@ class PackageTest extends TestCase
             public function services(): array
             {
                 return [
-                    'dependency' => function () {
-                        return (object)['x' => 'Works!'];
+                    'dependency' => static function (): object {
+                        return (object) ['x' => 'Works!'];
                     },
-                    'service' => function (ContainerInterface $container) {
+                    'service' => static function (ContainerInterface $container): object {
                         $works = $container->get('dependency')->x;
 
-                        return new class(['works?' => $works]) extends \ArrayObject {};
-                    }
+                        return new class (['works?' => $works]) extends \ArrayObject
+                        {
+                        };
+                    },
                 ];
             }
 
             public function extensions(): array
             {
                 return [
-                    'service' => function (\ArrayObject $current) {
-                        return new class ($current) {
-                            public $object;
+                    'service' => function (\ArrayObject $current): object {
+                        return new class ($current)
+                        {
+                            public \ArrayObject $object; // phpcs:ignore
+
                             public function __construct(\ArrayObject $object)
                             {
                                 $this->object = $object;
@@ -777,7 +784,7 @@ class PackageTest extends TestCase
                                 return $this->object->offsetGet('works?');
                             }
                         };
-                    }
+                    },
                 ];
             }
 
@@ -787,7 +794,7 @@ class PackageTest extends TestCase
             }
         };
 
-        $actual = Package::new($this->mockProperties())
+        $actual = Package::new($this->stubProperties())
             ->addModule($module)
             ->build()
             ->container()
@@ -802,16 +809,16 @@ class PackageTest extends TestCase
      */
     public function testBuildPassingModulesToBoot(): void
     {
-        $module1 = $this->mockModule('module_1', ServiceModule::class);
+        $module1 = $this->stubModule('module_1', ServiceModule::class);
         $module1->expects('services')->andReturn($this->stubServices('service_1'));
 
-        $module2 = $this->mockModule('module_2', ServiceModule::class);
+        $module2 = $this->stubModule('module_2', ServiceModule::class);
         $module2->expects('services')->andReturn($this->stubServices('service_2'));
 
-        $module3 = $this->mockModule('module_3', ServiceModule::class);
+        $module3 = $this->stubModule('module_3', ServiceModule::class);
         $module3->expects('services')->andReturn($this->stubServices('service_3'));
 
-        $package = Package::new($this->mockProperties('test', true))
+        $package = Package::new($this->stubProperties('test', true))
             ->addModule($module1)
             ->addModule($module2)
             ->build();
@@ -831,16 +838,16 @@ class PackageTest extends TestCase
      */
     public function testBootFailsIfPassingNotAddedModulesAfterContainer(): void
     {
-        $module1 = $this->mockModule('module_1', ServiceModule::class);
+        $module1 = $this->stubModule('module_1', ServiceModule::class);
         $module1->expects('services')->andReturn($this->stubServices('service_1'));
 
-        $module2 = $this->mockModule('module_2', ServiceModule::class);
+        $module2 = $this->stubModule('module_2', ServiceModule::class);
         $module2->expects('services')->andReturn($this->stubServices('service_2'));
 
-        $module3 = $this->mockModule('module_3', ServiceModule::class);
+        $module3 = $this->stubModule('module_3', ServiceModule::class);
         $module3->allows('services')->andReturn($this->stubServices('service_3'));
 
-        $package = Package::new($this->mockProperties('test', true))
+        $package = Package::new($this->stubProperties('test', true))
             ->addModule($module1)
             ->addModule($module2)
             ->build();
@@ -865,10 +872,10 @@ class PackageTest extends TestCase
     {
         $exception = new \Exception('Test');
 
-        $module = $this->mockModule('id', ExecutableModule::class);
+        $module = $this->stubModule('id', ExecutableModule::class);
         $module->expects('run')->andThrow($exception);
 
-        $package = Package::new($this->mockProperties())->addModule($module);
+        $package = Package::new($this->stubProperties())->addModule($module);
 
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BOOT))
             ->once()
@@ -887,10 +894,10 @@ class PackageTest extends TestCase
     {
         $exception = new \Exception('Test');
 
-        $module = $this->mockModule('id', ExecutableModule::class);
+        $module = $this->stubModule('id', ExecutableModule::class);
         $module->expects('run')->andThrow($exception);
 
-        $package = Package::new($this->mockProperties('basename', true))->addModule($module);
+        $package = Package::new($this->stubProperties('basename', true))->addModule($module);
 
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BOOT))
             ->once()
@@ -904,7 +911,7 @@ class PackageTest extends TestCase
      * When multiple calls to `Package::addPackage()` throw an exception, and debug is off, we
      * expect none of them to bubble up, and the first to cause the "build failed" action.
      * We also expect the Package to be in errored status.
-     * We expect all other `Package::addPackage()` exceptions to do not fire action hook.@psalm-allow-private-mutation
+     * We expect all other `Package::addPackage()` exceptions to do not fire action hook.
      * We expect Package::build()` to fail without doing anything. Finally, when `Package::boot()`
      * is called, we expect the action "boot failed" to be called, and the passed exception to have
      * an exception hierarchy with all the thrown exceptions.
@@ -915,13 +922,13 @@ class PackageTest extends TestCase
     {
         $exception = new \Exception('Test 1');
 
-        $module1 = $this->mockModule('one', ServiceModule::class);
+        $module1 = $this->stubModule('one', ServiceModule::class);
         $module1->expects('services')->andThrow($exception);
 
-        $module2 = $this->mockModule('two', ServiceModule::class);
+        $module2 = $this->stubModule('two', ServiceModule::class);
         $module2->expects('services')->never();
 
-        $package = Package::new($this->mockProperties());
+        $package = Package::new($this->stubProperties());
 
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BUILD))
             ->once()
@@ -960,15 +967,15 @@ class PackageTest extends TestCase
     {
         $exception = new \Exception('Test 1');
 
-        $module1 = $this->mockModule('one', ServiceModule::class);
+        $module1 = $this->stubModule('one', ServiceModule::class);
         $module1->expects('services')->andThrow($exception);
 
-        $module2 = $this->mockModule('two', ServiceModule::class);
+        $module2 = $this->stubModule('two', ServiceModule::class);
         $module2->expects('services')->never();
 
-        $package = Package::new($this->mockProperties());
+        $package = Package::new($this->stubProperties());
 
-        $connected = Package::new($this->mockProperties());
+        $connected = Package::new($this->stubProperties());
         $connected->boot();
 
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BUILD))
@@ -1015,7 +1022,7 @@ class PackageTest extends TestCase
     {
         $exception = new \Exception('Test');
 
-        $package = Package::new($this->mockProperties());
+        $package = Package::new($this->stubProperties());
 
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_INIT))
             ->once()
@@ -1053,7 +1060,7 @@ class PackageTest extends TestCase
     {
         $exception = new \Exception('Test');
 
-        $package = Package::new($this->mockProperties('basename', true));
+        $package = Package::new($this->stubProperties('basename', true));
 
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_INIT))
             ->once()

--- a/tests/unit/Properties/BasePropertiesTest.php
+++ b/tests/unit/Properties/BasePropertiesTest.php
@@ -18,7 +18,7 @@ class BasePropertiesTest extends TestCase
         $expectedName = 'foo';
         $expectedPath = __DIR__ . '/';
 
-        $testee = $this->createBaseProperties(
+        $testee = $this->factoryBaseProperties(
             $expectedName,
             $expectedPath
         );
@@ -44,11 +44,12 @@ class BasePropertiesTest extends TestCase
     }
 
     /**
-     * @dataProvider baseNameDataProvider
+     * @test
+     * @dataProvider provideBaseNameData
      */
     public function testBaseNameSanitization(string $baseName, string $sanitizedBaseName): void
     {
-        $testee = $this->createBaseProperties(
+        $testee = $this->factoryBaseProperties(
             $baseName,
             ''
         );
@@ -56,7 +57,10 @@ class BasePropertiesTest extends TestCase
         static::assertSame($sanitizedBaseName, $testee->baseName());
     }
 
-    public function baseNameDataProvider(): iterable
+    /**
+     * @return \Generator
+     */
+    public static function provideBaseNameData(): \Generator
     {
         yield 'empty' => ['', ''];
         yield 'word' => ['foo', 'foo'];
@@ -66,19 +70,29 @@ class BasePropertiesTest extends TestCase
         yield 'single file' => ['package.php', 'package'];
     }
 
-    private function createBaseProperties(
+    /**
+     * @param string $baseName
+     * @param string $basePath
+     * @param string|null $baseUrl
+     * @param array $properties
+     * @return BaseProperties
+     */
+    private function factoryBaseProperties(
         string $baseName,
         string $basePath,
         string $baseUrl = null,
         array $properties = []
     ): BaseProperties {
-        return new class($baseName, $basePath, $baseUrl, $properties) extends BaseProperties {
+
+        return new class ($baseName, $basePath, $baseUrl, $properties) extends BaseProperties
+        {
             public function __construct(
                 string $baseName,
                 string $basePath,
                 string $baseUrl = null,
                 array $properties = []
             ) {
+
                 parent::__construct($baseName, $basePath, $baseUrl, $properties);
             }
         };

--- a/tests/unit/Properties/LibraryPropertiesTest.php
+++ b/tests/unit/Properties/LibraryPropertiesTest.php
@@ -119,6 +119,7 @@ class LibraryPropertiesTest extends TestCase
                     "name" => $expectedAuthor,
                     "homepage" => $expectedAuthorUri,
                 ],
+                "Invalid Author <invalid.author@example.com>",
             ],
             "keywords" => $expectedKeywords,
             "require" => [

--- a/tests/unit/Properties/LibraryPropertiesTest.php
+++ b/tests/unit/Properties/LibraryPropertiesTest.php
@@ -16,8 +16,9 @@ class LibraryPropertiesTest extends TestCase
      */
     public function testForLibraryInvalidFile(): void
     {
-        static::expectException(\Exception::class);
-        LibraryProperties::new('non-existing.file');
+        $this->expectException(\Exception::class);
+
+        LibraryProperties::new('non-existing.file')->basePath();
     }
 
     /**
@@ -104,7 +105,7 @@ class LibraryPropertiesTest extends TestCase
         $expectedDomainPath = 'languages/';
         $expectedName = "Properties Test";
         $expectedTextDomain = 'properties-test';
-        $expectedUri = 'http://github.com/inpsyde/modularity';
+        $expectedUri = 'https://github.com/inpsyde/modularity';
         $expectedVersion = '1.0';
         $expectedPhpVersion = "7.4";
         $expectedWpVersion = "5.3";
@@ -165,7 +166,7 @@ class LibraryPropertiesTest extends TestCase
      */
     public function testPhpDevRequireParsing(string $requirement, ?string $expected): void
     {
-        $which = random_int(1, 10) > 5 ? 'require-dev' : 'require';
+        $which = (random_int(1, 10) > 5) ? 'require-dev' : 'require';
 
         $composerJsonData = [
             'name' => 'inpsyde/some-package_name',
@@ -181,54 +182,18 @@ class LibraryPropertiesTest extends TestCase
         ];
         $root = vfsStream::setup('root', null, $structure);
 
-        $testee = LibraryProperties::new($root->url() . '/json/composer.json');
-        $php = $testee->requiresPhp();
+        $properties = LibraryProperties::new($root->url() . '/json/composer.json');
+        $requiresPhp = $properties->requiresPhp();
 
-        static::assertSame($expected, $php, "For requirement: '{$requirement}'");
+        static::assertSame($expected, $requiresPhp, "For requirement: '{$requirement}'");
     }
 
     /**
-     * @test
+     * @return \Generator
      */
-    public function testBaseUrlCanBeSet(): void
+    public static function providePhpRequirements(): \Generator
     {
-        $root = vfsStream::setup('root', null, ['composer.json' => '{"name": "vendor/test"}']);
-
-        $properties = LibraryProperties::new($root->url() . '/composer.json');
-
-        static::assertNull($properties->baseUrl());
-
-        $properties->withBaseUrl('https://example.com');
-        static::assertSame('https://example.com/', $properties->baseUrl());
-    }
-
-    /**
-     * @test
-     */
-    public function testBaseUrlCanNotBeOverridden(): void
-    {
-        $root = vfsStream::setup('root', null, ['composer.json' => '{"name": "vendor/test"}']);
-
-        $properties = LibraryProperties::new(
-            $root->url() . '/composer.json',
-            'https://example.com'
-        );
-
-        static::assertSame('https://example.com/', $properties->baseUrl());
-
-        $this->expectExceptionMessageMatches('/not overridable/i');
-
-        $properties->withBaseUrl('https://example.com/something');
-    }
-
-    /**
-     * @return array
-     */
-    public function providePhpRequirements(): array
-    {
-        // [requirement, expected]
-
-        return [
+        yield from [
             // simple requirements
             ['7.1', '7.1'],
             ['7.1.3-dev', '7.1.3'],
@@ -276,5 +241,39 @@ class LibraryPropertiesTest extends TestCase
             ['dev-master', null],
             ['dev-foo#abcde', null],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function testBaseUrlCanBeSet(): void
+    {
+        $root = vfsStream::setup('root', null, ['composer.json' => '{"name": "vendor/test"}']);
+
+        $properties = LibraryProperties::new($root->url() . '/composer.json');
+
+        static::assertNull($properties->baseUrl());
+
+        $properties->withBaseUrl('https://example.com');
+        static::assertSame('https://example.com/', $properties->baseUrl());
+    }
+
+    /**
+     * @test
+     */
+    public function testBaseUrlCanNotBeOverridden(): void
+    {
+        $root = vfsStream::setup('root', null, ['composer.json' => '{"name": "vendor/test"}']);
+
+        $properties = LibraryProperties::new(
+            $root->url() . '/composer.json',
+            'https://example.com'
+        );
+
+        static::assertSame('https://example.com/', $properties->baseUrl());
+
+        $this->expectExceptionMessageMatches('/not overridable/i');
+
+        $properties->withBaseUrl('https://example.com/something');
     }
 }

--- a/tests/unit/Properties/PluginPropertiesTest.php
+++ b/tests/unit/Properties/PluginPropertiesTest.php
@@ -7,7 +7,7 @@ namespace Inpsyde\Modularity\Tests\Unit\Properties;
 use Inpsyde\Modularity\Properties\Properties;
 use Inpsyde\Modularity\Properties\PluginProperties;
 use Inpsyde\Modularity\Tests\TestCase;
-use \Brain\Monkey\Functions;
+use Brain\Monkey\Functions;
 
 class PluginPropertiesTest extends TestCase
 {
@@ -22,11 +22,11 @@ class PluginPropertiesTest extends TestCase
         $expectedDomainPath = 'languages/';
         $expectedName = "Properties Test";
         $expectedTextDomain = 'properties-test';
-        $expectedUri = 'http://github.com/inpsyde/modularity';
+        $expectedUri = 'https://github.com/inpsyde/modularity';
         $expectedVersion = '1.0';
         $expectedPhpVersion = "7.4";
         $expectedWpVersion = "5.3";
-        $expectedNetwork = true;
+        $expectedNetwork = random_int(1, 1000) > 500;
 
         $expectedPluginMainFile = '/app/wp-content/plugins/plugin-dir/plugin-name.php';
         $expectedBaseName = 'plugin-dir/plugin-name.php';
@@ -55,34 +55,32 @@ class PluginPropertiesTest extends TestCase
         Functions\expect('plugin_basename')->andReturn($expectedBaseName);
         Functions\expect('plugin_dir_path')->andReturn($expectedBasePath);
 
-        $testee = PluginProperties::new($expectedPluginMainFile);
+        $properties = PluginProperties::new($expectedPluginMainFile);
 
-        static::assertInstanceOf(Properties::class, $testee);
-        static::assertSame($expectedDescription, $testee->description());
-        static::assertSame($expectedAuthor, $testee->author());
-        static::assertSame($expectedAuthorUri, $testee->authorUri());
-        static::assertSame($expectedDomainPath, $testee->domainPath());
-        static::assertSame($expectedName, $testee->name());
-        static::assertSame($expectedTextDomain, $testee->textDomain());
-        static::assertSame($expectedUri, $testee->uri());
-        static::assertSame($expectedVersion, $testee->version());
-        static::assertSame($expectedWpVersion, $testee->requiresWp());
-        static::assertSame($expectedPhpVersion, $testee->requiresPhp());
-        static::assertSame($expectedSanitizedBaseName, $testee->baseName());
+        static::assertInstanceOf(Properties::class, $properties);
+        static::assertSame($expectedDescription, $properties->description());
+        static::assertSame($expectedAuthor, $properties->author());
+        static::assertSame($expectedAuthorUri, $properties->authorUri());
+        static::assertSame($expectedDomainPath, $properties->domainPath());
+        static::assertSame($expectedName, $properties->name());
+        static::assertSame($expectedTextDomain, $properties->textDomain());
+        static::assertSame($expectedUri, $properties->uri());
+        static::assertSame($expectedVersion, $properties->version());
+        static::assertSame($expectedWpVersion, $properties->requiresWp());
+        static::assertSame($expectedPhpVersion, $properties->requiresPhp());
+        static::assertSame($expectedSanitizedBaseName, $properties->baseName());
         // Custom to Plugins
-        static::assertSame($expectedNetwork, $testee->network());
-        static::assertSame($expectedPluginMainFile, $testee->pluginMainFile());
+        static::assertSame($expectedNetwork, $properties->network());
+        static::assertSame($expectedPluginMainFile, $properties->pluginMainFile());
     }
 
     /**
+     * @test
+     * @runInSeparateProcess
+     * @dataProvider provideRequiresPluginsData
+     *
      * @param string $requiresPlugins
      * @param array $expected
-     *
-     * @test
-     *
-     * @runInSeparateProcess
-     *
-     * @dataProvider provideRequiresPluginsData
      */
     public function testRequiresPlugins(string $requiresPlugins, array $expected): void
     {
@@ -98,16 +96,16 @@ class PluginPropertiesTest extends TestCase
 
         Functions\expect('wp_normalize_path')->andReturnFirstArg();
 
-        $testee = PluginProperties::new($pluginMainFile);
-        static::assertEquals($expected, $testee->requiresPlugins());
+        $properties = PluginProperties::new($pluginMainFile);
+        static::assertEquals($expected, $properties->requiresPlugins());
     }
 
     /**
-     * @return array[]
+     * @return \Generator
      */
-    public function provideRequiresPluginsData(): array
+    public static function provideRequiresPluginsData(): \Generator
     {
-        return [
+        yield from [
             'no dependencies' => [
                 '',
                 [],
@@ -144,14 +142,14 @@ class PluginPropertiesTest extends TestCase
         Functions\expect('plugin_basename')->andReturn($expectedBaseName);
         Functions\expect('plugin_dir_path')->andReturn($expectedBasePath);
 
-        $testee = PluginProperties::new($pluginMainFile);
+        $properties = PluginProperties::new($pluginMainFile);
 
         Functions\expect('is_plugin_active')
             ->andReturnUsing(static function (string $baseName) use ($expectedBaseName): bool {
                 return $baseName === $expectedBaseName;
             });
 
-        static::assertTrue($testee->isActive());
+        static::assertTrue($properties->isActive());
     }
 
     /**
@@ -174,8 +172,8 @@ class PluginPropertiesTest extends TestCase
                 return $baseName === $expectedBaseName;
             });
 
-        $testee = PluginProperties::new($pluginMainFile);
-        static::assertTrue($testee->isNetworkActive());
+        $properties = PluginProperties::new($pluginMainFile);
+        static::assertTrue($properties->isNetworkActive());
     }
 
     /**
@@ -198,7 +196,6 @@ class PluginPropertiesTest extends TestCase
             [
                 'Author' => $expectedAuthor,
                 'AuthorURI' => $expectedAuthorUri,
-
             ],
             $customHeaders
         );
@@ -209,33 +206,32 @@ class PluginPropertiesTest extends TestCase
         Functions\expect('plugin_basename')->andReturn($expectedBaseName);
         Functions\expect('plugin_dir_path')->andReturn($expectedBasePath);
 
-        $testee = PluginProperties::new($pluginMainFile);
+        $properties = PluginProperties::new($pluginMainFile);
 
         // Check if PluginProperties do behave as normal
-        static::assertSame($expectedSanitizedBaseName, $testee->baseName());
-        static::assertSame($expectedBasePath, $testee->basePath());
+        static::assertSame($expectedSanitizedBaseName, $properties->baseName());
+        static::assertSame($expectedBasePath, $properties->basePath());
 
         // Test default Headers
-        static::assertSame($expectedAuthor, $testee->author());
-        static::assertSame($expectedAuthor, $testee->get(Properties::PROP_AUTHOR));
-        static::assertSame($expectedAuthorUri, $testee->authorUri());
-        static::assertSame($expectedAuthorUri, $testee->get(Properties::PROP_AUTHOR_URI));
+        static::assertSame($expectedAuthor, $properties->author());
+        static::assertSame($expectedAuthor, $properties->get(Properties::PROP_AUTHOR));
+        static::assertSame($expectedAuthorUri, $properties->authorUri());
+        static::assertSame($expectedAuthorUri, $properties->get(Properties::PROP_AUTHOR_URI));
 
         // Test headers from get_plugin_data() are removed from properties
         // "Author" will be mapped to Properties::PROP_AUTHOR
-        static::assertFalse($testee->has('Author'));
-        static::assertFalse($testee->has('AuthorURI'));
+        static::assertFalse($properties->has('Author'));
+        static::assertFalse($properties->has('AuthorURI'));
 
         // Test custom Headers
         foreach ($customHeaders as $key => $value) {
-            static::assertTrue($testee->has($key));
-            static::assertSame($value, $testee->get($key));
+            static::assertTrue($properties->has($key));
+            static::assertSame($value, $properties->get($key));
         }
     }
 
     /**
-     * Provides custom Plugin Headers which will
-     * be returned by get_plugin_data()
+     * @return \Generator
      */
     public function provideCustomHeaders(): \Generator
     {
@@ -255,16 +251,13 @@ class PluginPropertiesTest extends TestCase
     }
 
     /**
+     * @test
+     * @runInSeparateProcess
+     * @dataProvider provideIsMuPluginData
      *
      * @param string $pluginPath
      * @param string $muPluginDir
      * @param bool $expected
-     *
-     * @test
-     *
-     * @runInSeparateProcess
-     *
-     * @dataProvider provideIsMuPluginData
      */
     public function testIsMuPlugin(string $pluginMainFile, string $muPluginDir, bool $expected): void
     {
@@ -279,16 +272,16 @@ class PluginPropertiesTest extends TestCase
 
         define('WPMU_PLUGIN_DIR', $muPluginDir);
 
-        $testee = PluginProperties::new($pluginMainFile);
-        static::assertSame($expected, $testee->isMuPlugin());
+        $properties = PluginProperties::new($pluginMainFile);
+        static::assertSame($expected, $properties->isMuPlugin());
     }
 
     /**
-     * @return array[]
+     * @return \Generator
      */
-    public function provideIsMuPluginData(): array
+    public static function provideIsMuPluginData(): \Generator
     {
-        return [
+        yield from [
             'is not mu-plugin' => [
                 '/wp-content/plugins/the-plugin/index.php',
                 '/wp-content/mu-plugins/',

--- a/tests/unit/Properties/ThemePropertiesTest.php
+++ b/tests/unit/Properties/ThemePropertiesTest.php
@@ -5,10 +5,9 @@ declare(strict_types=1);
 namespace Inpsyde\Modularity\Tests\Unit\Properties;
 
 use Inpsyde\Modularity\Properties\Properties;
-use Inpsyde\Modularity\Properties\PluginProperties;
 use Inpsyde\Modularity\Properties\ThemeProperties;
 use Inpsyde\Modularity\Tests\TestCase;
-use \Brain\Monkey\Functions;
+use Brain\Monkey\Functions;
 
 class ThemePropertiesTest extends TestCase
 {
@@ -23,7 +22,7 @@ class ThemePropertiesTest extends TestCase
         $expectedDomainPath = 'languages/';
         $expectedName = "Properties Test";
         $expectedTextDomain = 'properties-test';
-        $expectedUri = 'http://github.com/inpsyde/modularity';
+        $expectedUri = 'https://github.com/inpsyde/modularity';
         $expectedVersion = '1.0';
         $expectedPhpVersion = "7.4";
         $expectedWpVersion = "5.3";
@@ -62,34 +61,34 @@ class ThemePropertiesTest extends TestCase
         Functions\expect('wp_get_theme')->with($expectedBasePath)->andReturn($themeStub);
         Functions\expect('get_stylesheet')->andReturn($expectedBaseName);
 
-        $testee = ThemeProperties::new($expectedBasePath);
+        $properties = ThemeProperties::new($expectedBasePath);
 
-        static::assertInstanceOf(Properties::class, $testee);
+        static::assertInstanceOf(Properties::class, $properties);
 
-        static::assertSame($expectedBaseName, $testee->baseName());
-        static::assertSame($expectedBasePath, $testee->basePath());
-        static::assertSame($expectedBaseUrl, $testee->baseUrl());
+        static::assertSame($expectedBaseName, $properties->baseName());
+        static::assertSame($expectedBasePath, $properties->basePath());
+        static::assertSame($expectedBaseUrl, $properties->baseUrl());
 
-        static::assertSame($expectedDescription, $testee->description());
-        static::assertSame($expectedAuthor, $testee->author());
-        static::assertSame($expectedAuthorUri, $testee->authorUri());
-        static::assertSame($expectedDomainPath, $testee->domainPath());
-        static::assertSame($expectedName, $testee->name());
-        static::assertSame($expectedTextDomain, $testee->textDomain());
-        static::assertSame($expectedUri, $testee->uri());
-        static::assertSame($expectedVersion, $testee->version());
-        static::assertSame($expectedWpVersion, $testee->requiresWp());
-        static::assertSame($expectedPhpVersion, $testee->requiresPhp());
+        static::assertSame($expectedDescription, $properties->description());
+        static::assertSame($expectedAuthor, $properties->author());
+        static::assertSame($expectedAuthorUri, $properties->authorUri());
+        static::assertSame($expectedDomainPath, $properties->domainPath());
+        static::assertSame($expectedName, $properties->name());
+        static::assertSame($expectedTextDomain, $properties->textDomain());
+        static::assertSame($expectedUri, $properties->uri());
+        static::assertSame($expectedVersion, $properties->version());
+        static::assertSame($expectedWpVersion, $properties->requiresWp());
+        static::assertSame($expectedPhpVersion, $properties->requiresPhp());
 
         // specific methods for Themes.
-        static::assertSame($expectedTags, $testee->tags());
-        static::assertSame('', $testee->template());
-        static::assertSame($expectedStatus, $testee->status());
+        static::assertSame($expectedTags, $properties->tags());
+        static::assertSame('', $properties->template());
+        static::assertSame($expectedStatus, $properties->status());
 
         // API for Themes
-        static::assertFalse($testee->isChildTheme());
-        static::assertTrue($testee->isCurrentTheme());
-        static::assertNull($testee->parentThemeProperties());
+        static::assertFalse($properties->isChildTheme());
+        static::assertTrue($properties->isCurrentTheme());
+        static::assertNull($properties->parentThemeProperties());
     }
 
     /**
@@ -114,9 +113,9 @@ class ThemePropertiesTest extends TestCase
 
         Functions\expect('wp_get_theme')->with($expectedBasePath)->andReturn($themeStub);
 
-        $testee = ThemeProperties::new($expectedBasePath);
+        $properties = ThemeProperties::new($expectedBasePath);
 
-        static::assertSame($expectedTemplate, $testee->template());
-        static::assertTrue($testee->isChildTheme());
+        static::assertSame($expectedTemplate, $properties->template());
+        static::assertTrue($properties->isChildTheme());
     }
 }


### PR DESCRIPTION
- PHPCS was not checked due to wrong configuration. Fix config (to latest Inpsyde CS) and the fix code
- Use typed properties when possible
- Use doc bloc consistently, delete unnecessary comments
- Update dependencies and GHA workflow (no need to support PHPUnit 8)
- Added Package::STATUS_BOOTING constant to alias Package::STATUS_MODULES_ADDED for clarity

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix (for PHPCS config) + maintenance update 

**What is the current behavior?** (You can also link to an open issue here)

PHPCS did not check anything.

**What is the new behavior (if this is a feature change)?**

No change in behavior. PHPCS now works (besides being updated).

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



**Other information**:
