### PR TITLE
Better Package's Status Checks

### DIFF
--- a/src/Container/PackageProxyContainer.php
+++ b/src/Container/PackageProxyContainer.php
@@ -53,12 +53,9 @@ class PackageProxyContainer implements ContainerInterface
             return true;
         }
 
-        /** TODO: We need a better way to deal with status checking besides equality */
         if (
-            $this->package->statusIs(Package::STATUS_INITIALIZED)
-            || $this->package->statusIs(Package::STATUS_MODULES_ADDED)
-            || $this->package->statusIs(Package::STATUS_READY)
-            || $this->package->statusIs(Package::STATUS_BOOTED)
+            $this->package->hasContainer()
+            || $this->package->hasReachedStatus(Package::STATUS_INITIALIZED)
         ) {
             $this->container = $this->package->container();
         }

--- a/src/Package.php
+++ b/src/Package.php
@@ -274,7 +274,7 @@ class Package
             }
 
             // Don't connect, if already booted or boot failed
-            $failed = $this->isFailed();
+            $failed = $this->hasFailed();
             if ($failed || $this->checkStatus(self::STATUS_INITIALIZED, '>=')) {
                 $reason = $failed ? 'an errored package' : 'a package with a built container';
                 $status = $failed ? 'failed' : 'built_container';
@@ -634,7 +634,7 @@ class Package
     /**
      * @return bool
      */
-    public function isFailed(): bool
+    public function hasFailed(): bool
     {
         return $this->status === self::STATUS_FAILED;
     }

--- a/src/Package.php
+++ b/src/Package.php
@@ -653,11 +653,11 @@ class Package
      */
     public function hasReachedStatus(int $status): bool
     {
-        if (!isset(self::SUCCESS_STATUSES[$status])) {
+        if ($this->hasFailed()) {
             return false;
         }
 
-        return !$this->hasFailed() && $this->checkStatus($status, '>=');
+        return isset(self::SUCCESS_STATUSES[$status]) && $this->checkStatus($status, '>=');
     }
 
     /**

--- a/src/Package.php
+++ b/src/Package.php
@@ -274,7 +274,7 @@ class Package
             }
 
             // Don't connect, if already booted or boot failed
-            $failed = $this->statusIs(self::STATUS_FAILED);
+            $failed = $this->isFailed();
             if ($failed || $this->checkStatus(self::STATUS_INITIALIZED, '>=')) {
                 $reason = $failed ? 'an errored package' : 'a package with a built container';
                 $status = $failed ? 'failed' : 'built_container';
@@ -607,6 +607,14 @@ class Package
     }
 
     /**
+     * @return bool
+     */
+    public function hasContainer(): bool
+    {
+        return $this->hasContainer;
+    }
+
+    /**
      * @return string
      */
     public function name(): string
@@ -621,6 +629,23 @@ class Package
     public function statusIs(int $status): bool
     {
         return $this->checkStatus($status);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFailed(): bool
+    {
+        return $this->status === self::STATUS_FAILED;
+    }
+
+    /**
+     * @param int $status
+     * @return bool
+     */
+    public function hasReachedStatus(int $status): bool
+    {
+        return ($this->status !== self::STATUS_FAILED) && $this->checkStatus($status, '>=');
     }
 
     /**

--- a/src/Package.php
+++ b/src/Package.php
@@ -153,6 +153,14 @@ class Package
     public const STATUS_BOOTED = 8;
     public const STATUS_FAILED = -8;
 
+    private const SUCCESS_STATUSES = [
+        self::STATUS_IDLE => self::STATUS_IDLE,
+        self::STATUS_INITIALIZED => self::STATUS_INITIALIZED,
+        self::STATUS_BOOTING => self::STATUS_BOOTING,
+        self::STATUS_READY => self::STATUS_READY,
+        self::STATUS_BOOTED => self::STATUS_BOOTED,
+    ];
+
     private const OPERATORS = [
         '<' => '<',
         '<=' => '<=',
@@ -275,7 +283,7 @@ class Package
 
             // Don't connect, if already booted or boot failed
             $failed = $this->hasFailed();
-            if ($failed || $this->checkStatus(self::STATUS_INITIALIZED, '>=')) {
+            if ($failed || $this->hasReachedStatus(self::STATUS_INITIALIZED)) {
                 $reason = $failed ? 'an errored package' : 'a package with a built container';
                 $status = $failed ? 'failed' : 'built_container';
                 $error = "{$errorMessage} to {$reason}.";
@@ -645,7 +653,11 @@ class Package
      */
     public function hasReachedStatus(int $status): bool
     {
-        return ($this->status !== self::STATUS_FAILED) && $this->checkStatus($status, '>=');
+        if (!isset(self::SUCCESS_STATUSES[$status])) {
+            return false;
+        }
+
+        return !$this->hasFailed() && $this->checkStatus($status, '>=');
     }
 
     /**

--- a/src/Properties/BaseProperties.php
+++ b/src/Properties/BaseProperties.php
@@ -10,13 +10,14 @@ class BaseProperties implements Properties
     protected string $baseName;
     protected string $basePath;
     protected ?string $baseUrl;
+    /** @var array<string, mixed> */
     protected array $properties;
 
     /**
      * @param string $baseName
      * @param string $basePath
      * @param string|null $baseUrl
-     * @param array $properties
+     * @param array<string, mixed> $properties
      */
     protected function __construct(
         string $baseName,

--- a/src/Properties/PluginProperties.php
+++ b/src/Properties/PluginProperties.php
@@ -65,6 +65,7 @@ class PluginProperties extends BaseProperties
             $properties[$key] = $pluginData[$pluginDataKey] ?? '';
             unset($pluginData[$pluginDataKey]);
         }
+        /** @var array<string, mixed> $properties */
         $properties = array_merge($properties, $pluginData);
 
         $this->pluginMainFile = wp_normalize_path($pluginMainFile);

--- a/tests/unit/Container/ContainerConfiguratorTest.php
+++ b/tests/unit/Container/ContainerConfiguratorTest.php
@@ -526,6 +526,7 @@ class ContainerConfiguratorTest extends TestCase
 
         $childContainer = new class ($expectedId, $expectedValue) implements ContainerInterface
         {
+            /** @var array<string, object> */
             private array $values = [];
 
             public function __construct(string $expectedId, object $expectedValue)

--- a/tests/unit/Container/ReadOnlyContainerTest.php
+++ b/tests/unit/Container/ReadOnlyContainerTest.php
@@ -94,6 +94,7 @@ class ReadOnlyContainerTest extends TestCase
 
         $childContainer = new class ($expectedKey, $expectedValue) implements ContainerInterface
         {
+            /** @var array<string, \stdClass> */
             private array $data = [];
 
             public function __construct(string $key, \stdClass $value)

--- a/tests/unit/PackageTest.php
+++ b/tests/unit/PackageTest.php
@@ -27,8 +27,27 @@ class PackageTest extends TestCase
         $package = Package::new($propertiesStub);
 
         static::assertTrue($package->statusIs(Package::STATUS_IDLE));
+        static::assertTrue($package->hasReachedStatus(Package::STATUS_IDLE));
+        static::assertFalse($package->hasReachedStatus(Package::STATUS_INITIALIZED));
+        static::assertFalse($package->hasReachedStatus(Package::STATUS_BOOTING));
+        static::assertFalse($package->hasReachedStatus(Package::STATUS_BOOTED));
+
+        $package->build();
+
+        static::assertFalse($package->statusIs(Package::STATUS_IDLE));
+        static::assertTrue($package->hasReachedStatus(Package::STATUS_IDLE));
+        static::assertTrue($package->hasReachedStatus(Package::STATUS_INITIALIZED));
+        static::assertFalse($package->hasReachedStatus(Package::STATUS_BOOTING));
+        static::assertFalse($package->hasReachedStatus(Package::STATUS_BOOTED));
+
         static::assertTrue($package->boot());
+
         static::assertTrue($package->statusIs(Package::STATUS_BOOTED));
+        static::assertTrue($package->hasReachedStatus(Package::STATUS_IDLE));
+        static::assertTrue($package->hasReachedStatus(Package::STATUS_INITIALIZED));
+        static::assertTrue($package->hasReachedStatus(Package::STATUS_BOOTING));
+        static::assertTrue($package->hasReachedStatus(Package::STATUS_BOOTED));
+
         static::assertSame($expectedName, $package->name());
         static::assertInstanceOf(Properties::class, $package->properties());
         static::assertInstanceOf(ContainerInterface::class, $package->container());
@@ -901,6 +920,7 @@ class PackageTest extends TestCase
         static::assertFalse($package->boot());
         static::assertTrue($package->statusIs(Package::STATUS_FAILED));
         static::assertTrue($package->hasFailed());
+        static::assertFalse($package->hasReachedStatus(Package::STATUS_IDLE));
     }
 
     /**

--- a/tests/unit/PackageTest.php
+++ b/tests/unit/PackageTest.php
@@ -900,6 +900,7 @@ class PackageTest extends TestCase
 
         static::assertFalse($package->boot());
         static::assertTrue($package->statusIs(Package::STATUS_FAILED));
+        static::assertTrue($package->isFailed());
     }
 
     /**
@@ -971,6 +972,7 @@ class PackageTest extends TestCase
             );
 
         static::assertFalse($package->addModule($module1)->addModule($module2)->build()->boot());
+        static::assertTrue($package->isFailed());
         static::assertTrue($package->statusIs(Package::STATUS_FAILED));
     }
 
@@ -1025,6 +1027,7 @@ class PackageTest extends TestCase
         static::assertFalse($package->connect($connected));
         static::assertFalse($package->boot());
         static::assertTrue($package->statusIs(Package::STATUS_FAILED));
+        static::assertTrue($package->isFailed());
     }
 
     /**
@@ -1066,6 +1069,7 @@ class PackageTest extends TestCase
 
         static::assertFalse($package->build()->boot());
         static::assertTrue($package->statusIs(Package::STATUS_FAILED));
+        static::assertTrue($package->isFailed());
     }
 
     /**
@@ -1089,6 +1093,7 @@ class PackageTest extends TestCase
                 static function (\Throwable $throwable) use ($exception, $package): void {
                     static::assertSame($exception, $throwable);
                     static::assertTrue($package->statusIs(Package::STATUS_FAILED));
+                    static::assertTrue($package->isFailed());
                 }
             );
 

--- a/tests/unit/PackageTest.php
+++ b/tests/unit/PackageTest.php
@@ -900,7 +900,7 @@ class PackageTest extends TestCase
 
         static::assertFalse($package->boot());
         static::assertTrue($package->statusIs(Package::STATUS_FAILED));
-        static::assertTrue($package->isFailed());
+        static::assertTrue($package->hasFailed());
     }
 
     /**
@@ -972,7 +972,7 @@ class PackageTest extends TestCase
             );
 
         static::assertFalse($package->addModule($module1)->addModule($module2)->build()->boot());
-        static::assertTrue($package->isFailed());
+        static::assertTrue($package->hasFailed());
         static::assertTrue($package->statusIs(Package::STATUS_FAILED));
     }
 
@@ -1027,7 +1027,7 @@ class PackageTest extends TestCase
         static::assertFalse($package->connect($connected));
         static::assertFalse($package->boot());
         static::assertTrue($package->statusIs(Package::STATUS_FAILED));
-        static::assertTrue($package->isFailed());
+        static::assertTrue($package->hasFailed());
     }
 
     /**
@@ -1069,7 +1069,7 @@ class PackageTest extends TestCase
 
         static::assertFalse($package->build()->boot());
         static::assertTrue($package->statusIs(Package::STATUS_FAILED));
-        static::assertTrue($package->isFailed());
+        static::assertTrue($package->hasFailed());
     }
 
     /**
@@ -1093,7 +1093,7 @@ class PackageTest extends TestCase
                 static function (\Throwable $throwable) use ($exception, $package): void {
                     static::assertSame($exception, $throwable);
                     static::assertTrue($package->statusIs(Package::STATUS_FAILED));
-                    static::assertTrue($package->isFailed());
+                    static::assertTrue($package->hasFailed());
                 }
             );
 

--- a/tests/unit/PackageTest.php
+++ b/tests/unit/PackageTest.php
@@ -47,6 +47,7 @@ class PackageTest extends TestCase
         static::assertTrue($package->hasReachedStatus(Package::STATUS_INITIALIZED));
         static::assertTrue($package->hasReachedStatus(Package::STATUS_BOOTING));
         static::assertTrue($package->hasReachedStatus(Package::STATUS_BOOTED));
+        static::assertFalse($package->hasReachedStatus(3));
 
         static::assertSame($expectedName, $package->name());
         static::assertInstanceOf(Properties::class, $package->properties());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature.


**What is the current behavior?** (You can also link to an open issue here)

The only public method to check package status is `Package::statusIs()`, which only chechs equality. A more flexible status check is possible via `Package::checkStatus()`, but that is proivate.

Moreover, there's no way to check if the Package has a container already generated. The Package has a `hasContainer` property, but that is provate.

Because of the two above points, `PackageProxyContainer` can not 100% determine when it is "safe" to access the proxied container.

**What is the new behavior (if this is a feature change)?**

Three new methods are added:

- `Package::isFailed()` which is a simpler way to do `Package::statusIs(Package::STATUS_FAILED)`
- `Package::hasReachedStatus()` which can check if the status is the one above or _above_
- `Package::hasContainer()` which tells when a Container is already created regardless teh status


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.


**Other information**:

This PR includes (in a separate commit) some CS fixes caused by new rules added to the Inpsyde Coding Standards.
