### PR TITLE
Introduce "generic" hook and refactor statuses and statuses actions hooks

### DIFF
--- a/docs/Application-flow.md
+++ b/docs/Application-flow.md
@@ -46,7 +46,7 @@ At any point of the flow, by holding an instance of the `Package`, it is possibl
 1. Upon instantiation, the `Package` status is at **`Package::STATUS_IDLE`**
 2. Modules can be added by directly calling **`Package::addModule()`** on the instance, and other packages can be added by calling **`Package::connect()`**.
 3. **`Package::build()`** is called.
-4. The `Package` status moves to **`Package::STATUS_INIT`**.
+4. The `Package` status moves to **`Package::STATUS_INITIALIZING`**.
 5. The **`Package::ACTION_INIT`** action hook is fired, passing the package instance as an argument. That allows external code to add modules and connect other packages.
 6. The `Package` status moves to **`Package::STATUS_INITIALIZED`**. No more modules can be added.
 7. The **`Package::ACTION_INITIALIZED`** action hook is fired, passing the package instance as an argument. That allows external code to get services from the container.
@@ -58,8 +58,8 @@ At any point of the flow, by holding an instance of the `Package`, it is possibl
 1. **`Package::boot()`** is called.
 2. `Package` status moves to **`Package::STATUS_BOOTING`**.
 3. **All executables modules run**. That is when all the application behavior happens.
-4. The `Package` status moves to **`Package::STATUS_READY`**.
-5. The **`Package::ACTION_READY`** action hook is fired, passing the package instance as an argument.
+4. The `Package` status moves to **`Package::STATUS_BOOTED`**.
+5. The **`Package::ACTION_BOOTED`** action hook is fired, passing the package instance as an argument.
 6. The `Package` status moves to **`Package::STATUS_DONE`**. The booting stage is completed. `Package::boot()` returns true.
 
 

--- a/docs/Application-flow.md
+++ b/docs/Application-flow.md
@@ -14,7 +14,7 @@ The `Package` class implements the two phases above, respectively, in the two me
 
 ### Single-phase VS two-phases bootstrapping
 
-It must be noted that **`Package::boot()`**, before proceeding with the "boot" phase, will execute the "build" phase if it hasn't been executed yet. In other words, it is not always necessary to explicitly call `Package::build()`, and many times calling `Package::build()` will suffice.
+It must be noted that **`Package::boot()`**, before proceeding with the "boot" phase, will execute the "build" phase if it hasn't been executed yet. In other words, it is not always necessary to explicitly call `Package::build()`, and many times calling `Package::boot()` will suffice.
 
 The following two code snippets are equivalent:
 

--- a/docs/Application-flow.md
+++ b/docs/Application-flow.md
@@ -30,7 +30,7 @@ Package::new($properties)->boot();
 
 ### Use cases for two-phased bootstrapping
 
-There might be at least two use case for explicitly calling `Package::build()`:
+There are at least two use cases for explicitly calling `Package::build()`:
 
 - When a plugin needs to "execute" pretty late during the WordPress loading, let's say, at `"template_redirect"`, we might to call `Package::boot()` at the latest possible time, but call `Package::build()` earlier to enable other packages to connect to it.
 - In unit tests, it might be desirable to access services from the container without any need to add hook via `Package::boot()`. In this specific case, the production code might only call `Package::boot()` while test might just use `Package::build()`.
@@ -44,7 +44,7 @@ At any point of the flow, by holding an instance of the `Package`, it is possibl
 ## The "build" phase
 
 1. Upon instantiation, the `Package` status is at **`Package::STATUS_IDLE`**
-2. Modules can be added by directly calling **`Package::addModule()`** on the instance and other packages can be added by calling **`Package::connect()`**.
+2. Modules can be added by directly calling **`Package::addModule()`** on the instance, and other packages can be added by calling **`Package::connect()`**.
 3. **`Package::build()`** is called.
 4. The `Package` status moves to **`Package::STATUS_INIT`**.
 5. The **`Package::ACTION_INIT`** action hook is fired, passing the package instance as an argument. That allows external code to add modules and connect other packages.

--- a/docs/Application-flow.md
+++ b/docs/Application-flow.md
@@ -1,55 +1,76 @@
 # The application flow
 
-Modularity implements its application flow in two stages:
+Modularity implements its application flow in two phases:
 
 - First, the application's dependencies tree is "composed" by collecting services declared in modules, adding sub-containers, and connecting other applications.
 - After that, the application dependency tree is locked, and the services are "consumed" to execute their behavior.
 
-The `Package` class implements the two stages above, respectively, in the two methods:
+The `Package` class implements the two phases above, respectively, in the two methods:
 
 - **`Package::build()`**
 - **`Package::boot()`**
 
-For convenience, `Package::boot()` is "smart enough" to call `build()` if it was not called before, so the following code (that makes the two stages evident):
+
+
+### Single-phase VS two-phases bootstrapping
+
+It must be noted that **`Package::boot()`**, before proceeding with the "boot" phase, will execute the "build" phase if it hasn't been executed yet. In other words, it is not always necessary to explicitly call `Package::build()`, and many times calling `Package::build()` will suffice.
+
+The following two code snippets are equivalent:
 
 ```php
 Package::new($properties)->build()->boot();
 ```
 
-is entirely equivalent to the following:
-
 ```php
 Package::new($properties)->boot();
 ```
 
+
+
+### Use cases for two-phased bootstrapping
+
+There might be at least two use case for explicitly calling `Package::build()`:
+
+- When a plugin needs to "execute" pretty late during the WordPress loading, let's say, at `"template_redirect"`, we might to call `Package::boot()` at the latest possible time, but call `Package::build()` earlier to enable other packages to connect to it.
+- In unit tests, it might be desirable to access services from the container without any need to add hook via `Package::boot()`. In this specific case, the production code might only call `Package::boot()` while test might just use `Package::build()`.
+
 Both stages are implemented through a series of *steps*, and the application status progresses as the steps are complete. In the process, a few action hooks are fired to allow external code to interact with the flow.
 
-At any point of the flow, by holding an instance of the `Package` is possible to inspect the current status via `Package::statusIs()`, passing as an argument one of the `Package::STATUS_*` constants.
+At any point of the flow, by holding an instance of the `Package`, it is possible to inspect the current status via `Package::statusIs()`, passing as an argument one of the `Package::STATUS_*` constants.
 
 
-## Building stage
+
+## The "build" phase
 
 1. Upon instantiation, the `Package` status is at **`Package::STATUS_IDLE`**
-2. Default modules can be added by calling **`Package::addModule()`** on the instance.
-3. The **`Package::ACTION_INIT`** action hook is fired, passing the package instance as an argument. That allows external code to add modules.
-4. The `Package` status moves to **`Package::STATUS_INITIALIZED`**. The "building" stage is completed, and no more modules can be added.
+2. Modules can be added by directly calling **`Package::addModule()`** on the instance and other packages can be added by calling **`Package::connect()`**.
+3. **`Package::build()`** is called.
+4. The `Package` status moves to **`Package::STATUS_INIT`**.
+5. The **`Package::ACTION_INIT`** action hook is fired, passing the package instance as an argument. That allows external code to add modules and connect other packages.
+6. The `Package` status moves to **`Package::STATUS_INITIALIZED`**. No more modules can be added.
+7. The **`Package::ACTION_INITIALIZED`** action hook is fired, passing the package instance as an argument. That allows external code to get services from the container.
 
 
-## Booting stage
 
-1. When the booting stage begins, the `Package` status moves to **`Package::STATUS_MODULES_ADDED`**.
-2. A read-only PSR-11 container is created. It can lazily resolve the dependency tree defined in the previous stage.
-3. **All executables modules run**. That is when all the application behavior happens. Note: Because the container is "lazy", only the consumed services are resolved. The `Package` never executes factory callbacks for services "registered" in the previous stage but not used in this stage.
+## The "boot" phase
+
+1. **`Package::boot()`** is called.
+2. `Package` status moves to **`Package::STATUS_BOOTING`**.
+3. **All executables modules run**. That is when all the application behavior happens.
 4. The `Package` status moves to **`Package::STATUS_READY`**.
-5. The **`Package::ACTION_READY`** action hook is fired, passing the package instance as an argument. External code hooking that action can access the read-only container instance, resolve services, and perform additional actions but not register modules.
-6. The `Package` status moves to **`Package::STATUS_BOOTED`**. The booting stage is completed. `Package::boot()` returns true.
+5. The **`Package::ACTION_READY`** action hook is fired, passing the package instance as an argument.
+6. The `Package` status moves to **`Package::STATUS_DONE`**. The booting stage is completed. `Package::boot()` returns true.
+
 
 
 ## The "failure flow"
 
 The steps listed above for the two stages represent the "happy paths". If any exception is thrown at any of the steps above, the flows are halted and the "failure flow" starts.
 
-### When the failure starts during the "building" stage
+
+
+### When the failure starts during the "build" phase
 
 1. The `Package` status moves to **`Package::STATUS_FAILED`**.
 2. The **`Package::ACTION_FAILED_BUILD`** action hook is fired, passing the raised `Throwable` as an argument.
@@ -57,7 +78,9 @@ The steps listed above for the two stages represent the "happy paths". If any ex
 4. If the `Properties` instance is _not_ in "debug mode", the **`Package::ACTION_FAILED_BOOT`** action hook is fired, passing a `Throwable` whose `previous` property is the `Throwable` thrown during the building stage. The "previous hierarchy" could be several levels if during the building stage many failures happened. 
 5. `Package::boot()` returns false.
 
-### When the failure starts during the "booting" stage
+
+
+### When the failure starts during the "boot" phase
 
 1. The `Package` status moves to **`Package::STATUS_FAILED`**.
 2. The **`Package::ACTION_FAILED_BOOT`** action hook is fired, passing the raised `Throwable` as an argument.
@@ -65,36 +88,15 @@ The steps listed above for the two stages represent the "happy paths". If any ex
 4. `Package::boot()` returns false.
 
 
-## A note about default modules passed to boot()
 
-The `Package::boot()` method accepts a list of modules. That has been deprecated since Modularity v1.7.
+## About modules passed to `Package::boot()`
 
-Considering that `Package::boot()` represents the "booting" stage that is supposed to happen *after* the "building" stage, it might be hard to figure out where the addition of those modules fits in the flows described above.
+Passing modules to add to `Package::boot()` has been deprecated since Modularity `v1.7.0`.
 
-When `Package::boot()` is called without calling `Package::build()` first, as in:
+For backward compatibility, when that happens, a deprecation notice is triggered (similarly to WordPress' `_deprecated_argument`) but modules are still added.
 
-```php
-Package::new($properties)->boot(new ModuleOne(), new ModuleTwo());
-```
+It must be noted, that when first calling `Package::build()` and after that `Package::boot()` passing modules as argument, we will add those modules _after_ the status is already at `Package::STATUS_INITIALIZED` (because of the `Package::build()` call) and, as mentioned above, that should not be possible.
 
-The code is equivalent to the following:
+The `Package` class still deals with this scenario aiming for 100% backward compatibility, but there's an edge case. If anything that listens to the `Package::ACTION_INITIALIZED` hook accesses the container (which is an accepted and documented possibility) the compiled container will be created, which means we can't add modules to it anymore. In this specific case, calling something like `$package->build()->boot($someModule)` will end-up in an exception.
 
-```php
-Package::new($properties)->addModule(new ModuleOne())->addModule(new ModuleTwo())->boot();
-```
-
-So the "building" flow is respected.
-
-However, when `Package::boot()` is called after `Package::build()`, as in:
-
-```php
-Package::new($properties)->build()->boot(new ModuleOne(), new ModuleTwo());
-```
-
-The `Package` is at the end of the "building" flow after `Package::build()` is called, but it must "jump" back in the middle of "building" flow to add the modules.
-
-In fact, after `Package::build()` is called the application status is at `Package::STATUS_INITIALIZED`, and no more modules can be added.
-
-However, for backward compatibility reasons, in that case, the `Package` temporarily "hacks" the status back to `Package::STATUS_IDLE` so modules can be added, and then resets it to `Package::STATUS_INITIALIZED` so that the "booting" stage can start as usual.
-
-This "hack" is why passing modules to `Package::boot()` has been deprecated and will be removed in the next major version when backward compatibility breaks are allowed.
+While this is a breakage of the backward compatibility promise, it is also true that `Package::build()` was introduced in `v1.7.0` when passing modules to `Package::boot()` was deprecated. Developers who have introduced `Package::build()` should also have removed any module passed to `Package::boot()`.

--- a/docs/Package.md
+++ b/docs/Package.md
@@ -24,9 +24,9 @@ It has been mentioned how during both the "build" and "boot" phases the `Package
 
 There are three package-specific hooks:
 
-- `Package::ACTION_INIT`, fired at the beginning of the "build" phase, enables adding modules or connecting packages to the passed `Package` instance.
+- `Package::ACTION_INITIALIZING`, fired at the beginning of the "build" phase, enables adding modules or connecting packages to the passed `Package` instance.
 - `Package::ACTION_INITIALIZED`, fired at the end of the "build" phase, enables external code to access `Package`'s container, resolving services. No modification to the `Package`'s services are possible at this time or later.
-- `Package::ACTION_READY`, fired at the end of the "boot" phase, enables external code to access `Package`'s instance at a stage where it did all its job by registering services and adding hook to WordPress.
+- `Package::ACTION_BOOTED`, fired at the end of the "boot" phase, enables external code to access `Package`'s instance at a stage where it did all its job by registering services and adding hook to WordPress.
 
 All the hooks above enable access to `Package` properties and to retrieve information about specific modules.
 
@@ -327,12 +327,12 @@ Access to the wrapped [properties instance](./Properties.md).
 
 Retrieve the current status of the application. The following statuses are available:
 
-| Status                        | Description                                                                       |
-|-------------------------------|-----------------------------------------------------------------------------------|
-| `Package::STATUS_IDLE`        | Before application is built or booted (`Package` instance just instantiated).     |
-| `Package::STATUS_INIT`        | Before `Package::build()` started processing modules.                             |
-| `Package::STATUS_INITIALIZED` | After `Package::build()` end processing modules.                                  |
-| `Package::STATUS_BOOTING`     | Before `Package::boot()` started processing executable modules' "run procedures". |
-| `Package::STATUS_READY`       | After `Package::boot()` ended processing executable modules' "run procedures".    |
-| `Package::STATUS_DONE`        | The application has successfully booted.                                          |
-| `Package::STATUS_FAILED`      | The application did not build/boot properly.                                      |
+| Status                         | Description                                                                       |
+|--------------------------------|-----------------------------------------------------------------------------------|
+| `Package::STATUS_IDLE`         | Before application is built or booted (`Package` instance just instantiated).     |
+| `Package::STATUS_INITIALIZING` | Before `Package::build()` started processing modules.                             |
+| `Package::STATUS_INITIALIZED`  | After `Package::build()` end processing modules.                                  |
+| `Package::STATUS_BOOTING`      | Before `Package::boot()` started processing executable modules' "run procedures". |
+| `Package::STATUS_BOOTED`       | After `Package::boot()` ended processing executable modules' "run procedures".    |
+| `Package::STATUS_DONE`         | The application has successfully completed both processes.                        |
+| `Package::STATUS_FAILED`       | The application did not build/boot properly.                                      |

--- a/docs/Package.md
+++ b/docs/Package.md
@@ -1,234 +1,170 @@
 # Package
-This is the central class, which will allow you to add multiple Containers, register Modules and use Properties to get more information about your Application.
 
-Aside from that, the `Package`-class will boot your Application on a specific point (like plugins_loaded) and grants access for other Applications via hook to register and extend Services via Modules.
+`Package` is the library's main class that manages different modules, containers, and embeds a "properties" object that provides information about the application.
+
+
+
+## "Build" and "Boot" procedures
+
+The `Package` class is responsible for "bootstrapping" the application and, by emitting hooks, enable external code to register and extend services, as well as "connecting" other `Package` instances sharing the containers.
+
+That happens in two separate phases, the "build" and "boot" phase.
+
+In the **"build" phase**, initialized by calling **`Package::build()`**, the class emits an hook that allow external code to add modules or connect other packages. After that, the package container is "locked" and no more services can be added.
+
+In the **"boot" phase**, initialized by calling **`Package::boot()`**, any "executable" module that was added in the "build" phase is now executed.
+
+More info about the two phases can be found in the ["Application flow" chapter](./Application-flow.md)
+
+
+
+## Action hooks
+
+It has been mentioned how during both the "build" and "boot" phases the `Package` instance emits hooks that allow external code to interact with it, e. g. by extending or connecting it.
+
+There are three package-specific hooks:
+
+- `Package::ACTION_INIT`, fired at the beginning of the "build" phase, enables adding modules or connecting packages to the passed `Package` instance.
+- `Package::ACTION_INITIALIZED`, fired at the end of the "build" phase, enables external code to access `Package`'s container, resolving services. No modification to the `Package`'s services are possible at this time or later.
+- `Package::ACTION_READY`, fired at the end of the "boot" phase, enables external code to access `Package`'s instance at a stage where it did all its job by registering services and adding hook to WordPress.
+
+All the hooks above enable access to `Package` properties and to retrieve information about specific modules.
+
+
+
+### Hooking package-specific hooks
+
+The three package-specific hooks are so called because their name is dynamic, and can be obtained via a `Package` instance, by calling `Package::hookName()` passing any of the hook name constant mentioned above. For example:
 
 ```php
-<?php
-Inpsyde\Modularity\Package::new($properties)->boot();
+add_action(
+    $package->hookName(Package::ACTION_INIT),
+    fn (Package $package) => $package->addModule(new SomeModule())
+);
 ```
 
-The `Package`-class contains the following public API:
-
-**Package::moduleStatus(): array**
-
-Returns an array of all Modules and the current status.
-
-**Package::moduleIs(string $moduleId, string $status): bool**
-
-Allows to check the status for a given `Module::id()`.
-
-Following `Module` statuses are available:
-
-| Status                                 | Description                                                  |
-| -------------------------------------- | ------------------------------------------------------------ |
-| `Package::MODULE_REGISTERED`           | A `ServiceModule` was added and returned a non-zero number of services. |
-| `Package::MODULE_REGISTERED_FACTORIES` | A `FactoryModule` was added and returned a non-zero number of factories. |
-| `Package::MODULE_EXTENDED`             | An `ExtendingModule` was added and returned a non-zero number of extension. |
-| `Package::MODULE_ADDED`                | _Any_ of the three statuses above applied, or a module implements `ExecutableModule` |
-| `Package::MODULE_NOT_ADDED`            | _None_ of the first three statuses applied for a modules that is non-executable. That might happen in two scenarios: a module only implemented base `Module` interface, or did not return any service/factory/extension. |
-| `Package::MODULE_EXECUTED`             | An `ExecutableModule::run()` method was called and returned `true`. |
-| `Package::MODULE_EXECUTION_FAILED`     | An `ExecutableModule::run()` method was called and returned `false`. |
-
-**Package::hookName(string $suffix = ''): string**
-
-Allows to generate the hookName for Package-class (see below)
-
-**Package::properties(): PropertiesInterface**
-
-Access to Properties.
-
-**Package::container(): ContainerInterface**
-
-Access to the compiled Container after the booting process is finished.
-
-**Package::name():string**
-
-A shortcut to `Properties::baseName()` which contains the name of your Application
-
-**Package::addModule(Module $module): self**
-
-Allows adding Modules from outside via custom Hooks triggered.
-
-**Package::statusIs(int $status): bool**
-
-Retrieve the current status of the Application. Following are available:
-
-- `Package::STATUS_IDLE` - before Application is booted.
-- `Package::STATUS_INITIALIZED` - after first init action is triggered.
-- `Package::STATUS_MODULES_ADDED` - after all modules have been added.
-- `Package::STATUS_READY` - after the "ready" action has been fired.
-- `Package::STATUS_BOOTED` - Application has successfully booted.
-- `Package::STATUS_FAILED_BOOT` - when Application did not boot properly.
 
 
+### Generic "init" hook
 
-## Access from external
+Besides the three package-specific hooks, the `Package` instance emits a single hook whose name is not dynamic, but is fired for every `Package` instance. 
 
-The recommended way to set up your Application is to provide a function in your Application namespace which returns an instance of Package. Here’s a short example of an “Acme”-Plugin:
+The hook name is stored in the `Package::ACTION_MODULARITY_INIT` constant, it is executed right after the package-specific `Package::ACTION_INIT` hook, and unlike the three package-specific hooks, it passes the package name as first argument and the `Package` instance as second.  
 
 ```php
-<?php
-
-declare(strict_types=1);
-
-/*
- * Plugin Name:       Acme
- * Author:            Inpsyde GmbH
- * Author URI:        https://inpsyde.com/
- * Version:           1.0.0
- * Text Domain:       acme
- */
-
-namespace Acme;
-
-use Inpsyde\Modularity;
-
-function plugin(): Modularity\Package {
-    static $package;
-    if (!$package) {
-        $properties = Modularity\Properties\PluginProperties::new(__FILE__);
-        $package = Modularity\Package::new($properties);
-    }
-
-   return $package;
-}
-
 add_action(
-    'plugins_loaded',
-    static function(): void {
-        plugin()->boot();
+    Package::ACTION_MODULARITY_INIT,
+    function (string $packageName, Package $package): void {
+        if (str_starts_with($packageName, 'acme-')) {
+            $package->connect(\Acme\someGlobalLibrary())
+        }
     }
 );
 ```
 
-By providing the `Acme\plugin()` function, you’ll enable external code to hook into your application:
+Among other things, this enables to easily apply the same operations to multiple packages without calling `function_exists()` and even without knowing in advance what packages will be there.
+
+
+
+## Usage example
+
+The following code shows how to use this class for a plugin. A theme or library usage would not differ much. 
 
 ```php
-<?php
+/* Plugin Name: Acme */
 
-declare(strict_types=1);
+namespace Acme;
 
+use Inpsyde\Modularity\{Package, Properties};
+
+function plugin(): Package {
+    static $package;
+    if (!$package) {
+        $properties = Properties\PluginProperties::new(__FILE__);
+        $package = Package::new($properties)
+            ->addModule(new ModuleOne())
+            ->addModule(new ModuleTwo());
+    }
+   return $package;
+}
+
+// An early hook. Not _too_ early to allow external code to extend the instance before
+// the call to `plugin()->build()` "locks" it. A late priority is used so that hooking
+// 'plugins_loaded' is still ok to call `plugin()` and extend the obtained `Package`.
+add_action('plugins_loaded', fn () => plugin()->build(), PHP_INT_MAX);
+
+// The latest hook the plugin can use to do its job.
+add_action('template_redirect', fn () => plugin()->boot());
+```
+
+The `Acme\plugin()` function above enables external code to use an action hook to extend the package, for example adding more modules:
+
+```php
 namespace FooBarInc;
 
 use Inpsyde\Modularity\Package;
 
-if (! function_exists('Acme\plugin')) {
-   return;
+if (function_exists('Acme\plugin')) {
+   add_action(
+        Acme\plugin()->hookName(Package::ACTION_INIT),
+        fn (Package $plugin) => $plugin->addModule(new MyModule())
+    );
 }
-
-add_action(
-    Acme\plugin()->hookName(Package::ACTION_INIT),
-    static function (Package $plugin): void {
-       $plugin->addModule(new MyModule());
-    }
-);
 ```
 
-## Building the package
 
-Sometimes, especially in unit tests, it might be desirable to obtain services as defined for the
-production code, but without calling any `ExecutableModule::run()`, which usually contains
-WP-dependant code, and therefore requires heavy mocking.
 
-For example, assuming a common `plugin()` function like the following:
+### Alternative usage using a plugin-specific hook
+
+An alternative to the previous example makes use of a plugin-specific hook to allow for extension. This hook is fired inside the `plugin()` function, right before calling `build()`:
 
 ```php
-function plugin(): Modularity\Package {
+use Inpsyde\Modularity\{Package, Properties};
+
+function plugin(): Package {
     static $package;
     if (!$package) {
-        $properties = Modularity\Properties\PluginProperties::new(__FILE__);
-        $package = Modularity\Package::new($properties)
-            ->addModule(new ModuleOne())
-            ->addModule(new ModuleTwo())
+        $properties = Properties\PluginProperties::new(__FILE__);
+        $package = Package::new($properties);
+        // Add default modules here...
+        do_action('acme-plugin.extend', $package);
+        $package->build();
     }
     return $package;
 }
+
+// The latest hook the plugin can use to do its job.
+add_action('template_redirect', fn () => plugin()->boot());
 ```
 
-In unit test it will be possible (as of v1.7+) to do something like the following:
+Thanks to that, any code that needs to extend this plugin, does not need to call `function_exists()`, and the bootstrap process is easier without a separate `build()`, still keeping `boot()` as late as possible. Extending code can look like the following:
 
 ```php
-$myService = plugin()->build()->container()->get(MyService::class);
-static::assertTrue($myService->isValid());
-```
+use Inpsyde\Modularity\Package;
 
-### Booting a built container
-
-The `Package::boot()` method can be called on already built package.
-
-For example, the following is a valid unit test code:
-
-```php
-$plugin = plugin()->build();
-$myService = $plugin->container()->get(MyService::class);
-
-static::assertTrue($myService->isValid());
-static::assertFalse($myService->isBooted());
-
-$plugin->boot();
-
-static::assertTrue($myService->isBooted());
-```
-
-### Deprecated boot parameters
-
-Before Modularity v1.7.0, it was an accepted practice to pass default modules to `Package::boot()`,
-as in:
-
-```php
 add_action(
-    'plugins_loaded',
-    static function(): void {
-        plugin()->boot(new ModuleOne(), new ModuleTwo());
+    'acme-plugin.extend',
+    function (Package $plugin): void {
+        $plugin->addModule(new MyModule());
     }
 );
 ```
 
-This is now deprecated to allow a better separation of the "building" and "booting" steps.
+This approach makes sense when we expect multiple external plugins/libraries/themes to extend our plugin, e. g. when we are writing a plugin we design to be extended via extensions.
 
-While it still works (and it will work up to version 2.0), it will emit a deprecation notice.
-
-The replacement is using `Package::addModule()`:
-
-```php
-plugin()->addModule(new ModuleOne())->addModule(new ModuleTwo())->boot();
-```
-
-There's only one case in which calling `Package::boot()` with default modules will throw an 
-exception (besides triggering a deprecated notice), that is when a passed modules was not added
-before `Package::addModule()` and an instance of the container was already obtained from the package.
-
-For example, this will throw an exception:
-
-```php
-$plugin = plugin()->build();
-
-// Now that container is built, passing modules to `boot()` will raise an exception, because we
-// can't add new modules to an already "compiled" container being that read-only.
-$container = $plugin->container();
-
-$plugin->boot(new ModuleOne());
-```
-
-To prevent the exception it would be necessary to add the module before calling `build()`, or  alternatively, to call `$plugin->boot(new ModuleOne())` _before_ calling `$plugin->container()`.
-In this latter case the exception is not thrown, but the deprecation will still be emitted.
 
 
 ## Connecting packages
 
-Every `Package` has a separate container, however sometimes it might be desirable access another package's services. For example from a plugin access one library services, or from a theme access a plugin's services.
+Every `Package` has a separate container, however it might be desirable access another package's services. For example, from a plugin access a library's services, or from a theme access a plugin's services.
 
-That can be done using the `Package::connect()` method.
-
-For example:
+That can be done using the `Package::connect()` method. Here's an example:
 
 ```php
-// a theme functions.php
+// Theme functions.php
+use Inpsyde\Modularity\{Package, Properties};
 
-$properties = Properties\ThemeProperties::new('/path/to/theme/dir/');
-$theme = Inpsyde\Modularity\Package::new($properties);
-
+$theme = Package::new(Properties\ThemeProperties::new(__DIR__));
 $theme->connect(\Acme\plugin());
 $theme->boot();
 ```
@@ -238,37 +174,165 @@ To note:
 - `Package::connect()` must be called **before** the package enters the "initialized" status, that is, before calling `Package::boot()` or `Package::build()`. If called later, no connections happen and it returns `false`
 - The package to be connected might be already booted or not. In the second case the connection will happen, but before accessing its services it has to be at least built, or an exception will happen.
 
-Package connection is a great way to create reusable libraries and services that can be used by many plugins. For example, it might be possible to have a *library* that has something like this:
+Package connection enables the creation of reusable libraries to be consumed by multiple plugins. For example, it might be possible to have a *library* that has something like this:
 
 ```php
 namespace Acme;
+
+use Inpsyde\Modularity\{Package, Properties};
 
 function myLibrary(): Package {
     static $lib;
     if (!$lib) {
         $properties = Properties\LibraryProperties::new('path/to/composer.json');
-        $lib = Inpsyde\Modularity\Package::new($properties);
-        $lib->addModule(new ModuleOne());
-        $lib->addModule(new ModuleTwo());
-        $lib->boot();
+        Package::new($properties)
+            ->addModule(new ModuleOne())
+            ->addModule(new ModuleTwo())
+            ->boot();
     }
     return $lib;
 }
 ```
 
-This would be autoloaded by Composer, but not being a plugin will not be called by WordPress.
+This function might be autoloaded via Composer, autoload, but not being a plugin, it will not be executed by WordPress.
 
-However, *many* plugins in the same installation could do:
+However, multiple plugins in the same installation could do:
 
 ```php
-/** @var Package $plugin */
 $plugin->connect(\Acme\myLibrary());
 ```
 
 Thanks to that, all plugins will be able to access the library's services in the same way they access own modules' services.
 
+Please note that by calling `Package::boot()` in the `myLibrary()` function immediately after having instantiated the `Package` instance will prevent any external code to extend the library, adding more modules or connecting other packages.
 
 
-### Accessing connected packages' properties 
+
+### Accessing connected packages' properties
 
 In modules, we can access package properties calling `$container->get(Package::PROPERTIES)`. If we'd like to access any connected package properties, we could do that using a key whose format is: `sprintf('%s.%s', $connectedPackage->name(), Package::PROPERTIES)`.
+
+
+
+## `Package` public API
+
+
+
+
+### `Package::boot(): bool`
+
+Executes the "boot" phase, and the "build" phase, if it has not be executed separately via `Package::build()`.
+
+
+
+### `Package::build(): static`
+
+Executes the "build" phase. The inner container is safely accessible after that, and no more services can be added to it.
+
+
+
+### `Package::connect(Package $package): bool`
+
+Connect the given package sharing their services with the calling `Package` instance.
+
+
+
+
+### `Package::connectedPackages(): array`
+
+Returns an array of names of packages connected via `Package::connect()`.
+
+
+
+
+### `Package::container(): ContainerInterface`
+
+Access to the compiled PSR-11 container. Throws an exception if called before the "build" phase is completed.
+
+
+
+### `Package::hasContainer(): bool`
+
+Returns true if a container has already be generated for the Package, regardless current status. Note: this might be true even in case of failures.
+
+
+
+### `Package::hasFailed(): bool`
+
+Returns true if the current status is failed.
+
+
+
+### `Package::hasReachedStatus(int $status): bool`
+
+Returns true if the current given status is either the current Package status, or a status the package has previously been. Please note that it will always return false when in a "failed" status (`Package::hasFailed()` returns true).
+
+For the list of available statuses see `Package::statusIs()` below.
+
+
+
+
+### `Package::hookName(string $suffix = ''): string`
+
+Generates the hook name for package-specific hooks.
+
+
+
+
+### `Package::isPackageConnected(string $packageName): bool`
+
+Returns `true` when give a name of a package previously connected via `Package::connect()`.
+
+
+
+
+### `Package::moduleIs(string $moduleId, string $status): bool`
+
+Used to check the status for a given `Module::id()`.  The following statuses are available:
+
+| Status                                 | Description                                                                                                                                                                                                              |
+|----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Package::MODULE_REGISTERED`           | A `ServiceModule` was added and returned a non-zero number of services.                                                                                                                                                  |
+| `Package::MODULE_REGISTERED_FACTORIES` | A `FactoryModule` was added and returned a non-zero number of factories.                                                                                                                                                 |
+| `Package::MODULE_EXTENDED`             | An `ExtendingModule` was added and returned a non-zero number of extension.                                                                                                                                              |
+| `Package::MODULE_ADDED`                | _Any_ of the three statuses above applied, or a module implements `ExecutableModule`                                                                                                                                     |
+| `Package::MODULE_NOT_ADDED`            | _None_ of the first three statuses applied for a modules that is non-executable. That might happen in two scenarios: a module only implemented base `Module` interface, or did not return any service/factory/extension. |
+| `Package::MODULE_EXECUTED`             | An `ExecutableModule::run()` method was called and returned `true`.                                                                                                                                                      |
+| `Package::MODULE_EXECUTION_FAILED`     | An `ExecutableModule::run()` method was called and returned `false`.                                                                                                                                                     |
+
+
+
+### `Package::moduleStatus(): array`
+
+Returns an associative array that maps module names to their current status.
+
+
+
+
+### `Package::name(): string`
+
+A shortcut to `Properties::baseName()`.
+
+
+
+
+### `Package::properties(): PropertiesInterface`
+
+Access to the wrapped [properties instance](./Properties.md).
+
+
+
+
+### `Package::statusIs(int $status): bool`
+
+Retrieve the current status of the application. The following statuses are available:
+
+| Status                        | Description                                                                       |
+|-------------------------------|-----------------------------------------------------------------------------------|
+| `Package::STATUS_IDLE`        | Before application is built or booted (`Package` instance just instantiated).     |
+| `Package::STATUS_INIT`        | Before `Package::build()` started processing modules.                             |
+| `Package::STATUS_INITIALIZED` | After `Package::build()` end processing modules.                                  |
+| `Package::STATUS_BOOTING`     | Before `Package::boot()` started processing executable modules' "run procedures". |
+| `Package::STATUS_READY`       | After `Package::boot()` ended processing executable modules' "run procedures".    |
+| `Package::STATUS_DONE`        | The application has successfully booted.                                          |
+| `Package::STATUS_FAILED`      | The application did not build/boot properly.                                      |

--- a/src/Container/PackageProxyContainer.php
+++ b/src/Container/PackageProxyContainer.php
@@ -76,9 +76,7 @@ class PackageProxyContainer implements ContainerInterface
         }
 
         $name = $this->package->name();
-        $status = $this->package->statusIs(Package::STATUS_FAILED)
-            ? 'is errored'
-            : 'is not ready yet';
+        $status = $this->package->hasFailed() ? 'is errored' : 'is not ready yet';
 
         $error = "Error retrieving service {$id} because package {$name} {$status}.";
         throw new class (esc_html($error)) extends \Exception implements ContainerExceptionInterface

--- a/src/Package.php
+++ b/src/Package.php
@@ -103,7 +103,7 @@ class Package
     /**
      * Action fired when a package connection failed.
      */
-    public const ACTION_FAILED_CONNECT = 'failed-connect';
+    public const ACTION_FAILED_CONNECT = 'failed-connection';
 
     /**
      * Action fired when a package is connected successfully.
@@ -156,6 +156,8 @@ class Package
     public const STATUS_MODULES_ADDED = self::STATUS_BOOTING;
     /** @deprecated  */
     public const ACTION_READY = self::ACTION_BOOTED;
+    /** @deprecated  */
+    public const ACTION_FAILED_CONNECTION = self::ACTION_FAILED_CONNECT;
 
     // Map of status to package-specific and global hook, both optional (i..e, null).
     private const STATUSES_ACTIONS_MAP = [

--- a/src/Package.php
+++ b/src/Package.php
@@ -131,9 +131,9 @@ class Package
      * @example
      * <code>
      * $package = Package::new();
-     * $package->statusIs(Package::IDLE); // true
+     * $package->statusIs(Package::STATUS_IDLE); // true
      * $package->build();
-     * $package->statusIs(Package::INITIALIZED); // true
+     * $package->statusIs(Package::STATUS_INITIALIZED); // true
      * $package->boot();
      * $package->statusIs(Package::STATUS_DONE); // true
      * </code>

--- a/src/Package.php
+++ b/src/Package.php
@@ -96,14 +96,19 @@ class Package
     public const ACTION_FAILED_BOOT = 'failed-boot';
 
     /**
-     * Action fired when a package is connected successfully.
+     * Action fired when adding a module failed.
      */
-    public const ACTION_PACKAGE_CONNECTED = 'package-connected';
+    public const ACTION_FAILED_ADD_MODULE = 'failed-add-module';
 
     /**
      * Action fired when a package connection failed.
      */
-    public const ACTION_FAILED_CONNECTION = 'failed-connection';
+    public const ACTION_FAILED_CONNECT = 'failed-connect';
+
+    /**
+     * Action fired when a package is connected successfully.
+     */
+    public const ACTION_PACKAGE_CONNECTED = 'package-connected';
 
     /**
      * Module states can be used to get information about your module.
@@ -254,7 +259,7 @@ class Package
             $status = $added ? self::MODULE_ADDED : self::MODULE_NOT_ADDED;
             $this->moduleProgress($module->id(), $status);
         } catch (\Throwable $throwable) {
-            $this->handleFailure($throwable, self::ACTION_FAILED_BUILD);
+            $this->handleFailure($throwable, self::ACTION_FAILED_ADD_MODULE);
         }
 
         return $this;
@@ -741,7 +746,7 @@ class Package
         $message = "Failed connecting package {$packageName} because {$reason}.";
 
         do_action(
-            $this->hookName(self::ACTION_FAILED_CONNECTION),
+            $this->hookName(self::ACTION_FAILED_CONNECT),
             $packageName,
             new \WP_Error('failed_connection', $message, $errorData)
         );

--- a/src/Package.php
+++ b/src/Package.php
@@ -152,6 +152,7 @@ class Package
     /** @deprecated  */
     public const STATUS_BOOTED = self::STATUS_DONE;
 
+    // Map of status to package-specific and global hook, both optional (i..e, null).
     private const STATUSES_ACTIONS_MAP = [
         self::STATUS_INIT => [self::ACTION_INIT, self::ACTION_MODULARITY_INIT],
         self::STATUS_INITIALIZED => [self::ACTION_INITIALIZED, null],

--- a/tests/unit/PackageTest.php
+++ b/tests/unit/PackageTest.php
@@ -424,6 +424,23 @@ class PackageTest extends TestCase
 
     /**
      * @test
+     * @runInSeparateProcess
+     */
+    public function testBootPassingModulesAddModules(): void
+    {
+        $module1 = $this->stubModule('module_1', ServiceModule::class);
+        $module1->allows('services')->andReturn($this->stubServices('service_1'));
+
+        $package = Package::new($this->stubProperties('test', true));
+
+        $this->ignoreDeprecations();
+        $package->boot($module1);
+
+        static::assertSame('service_1', $package->container()->get('service_1')['id']);
+    }
+
+    /**
+     * @test
      */
     public function testAddModuleFailsAfterBuild(): void
     {
@@ -620,6 +637,7 @@ class PackageTest extends TestCase
         $package->boot();
 
         static::assertSame(range(0, 4), $log);
+        static::assertCount(1, $package->connectedPackages());
     }
 
     /**
@@ -684,6 +702,7 @@ class PackageTest extends TestCase
         $package->build()->boot();
 
         static::assertSame(range(0, 4), $log);
+        static::assertCount(1, $package->connectedPackages());
     }
 
     /**
@@ -742,6 +761,7 @@ class PackageTest extends TestCase
         $package->build();
 
         static::assertSame(range(0, 3), $log);
+        static::assertCount(1, $package->connectedPackages());
     }
 
     /**

--- a/tests/unit/PackageTest.php
+++ b/tests/unit/PackageTest.php
@@ -1195,7 +1195,7 @@ class PackageTest extends TestCase
         $package1 = $this->stubSimplePackage('1');
         $package2 = $this->stubSimplePackage('2');
 
-        Monkey\Actions\expectDone($package2->hookName(Package::ACTION_FAILED_CONNECTION))
+        Monkey\Actions\expectDone($package2->hookName(Package::ACTION_FAILED_CONNECT))
             ->once()
             ->with($package1->name(), \Mockery::type(\WP_Error::class));
 
@@ -1213,7 +1213,7 @@ class PackageTest extends TestCase
         $package1 = $this->stubSimplePackage('1');
         $package2 = $this->stubSimplePackage('2', true);
 
-        Monkey\Actions\expectDone($package2->hookName(Package::ACTION_FAILED_CONNECTION))
+        Monkey\Actions\expectDone($package2->hookName(Package::ACTION_FAILED_CONNECT))
             ->once()
             ->with($package1->name(), \Mockery::type(\WP_Error::class));
 
@@ -1232,7 +1232,7 @@ class PackageTest extends TestCase
         $package1 = $this->stubSimplePackage('1');
         $package2 = $this->stubSimplePackage('2');
 
-        Monkey\Actions\expectDone($package2->hookName(Package::ACTION_FAILED_CONNECTION))
+        Monkey\Actions\expectDone($package2->hookName(Package::ACTION_FAILED_CONNECT))
             ->once()
             ->with($package1->name(), \Mockery::type(\WP_Error::class));
 
@@ -1250,7 +1250,7 @@ class PackageTest extends TestCase
         $package1 = $this->stubSimplePackage('1');
         $package2 = $this->stubSimplePackage('2', true);
 
-        Monkey\Actions\expectDone($package2->hookName(Package::ACTION_FAILED_CONNECTION))
+        Monkey\Actions\expectDone($package2->hookName(Package::ACTION_FAILED_CONNECT))
             ->once()
             ->with($package1->name(), \Mockery::type(\WP_Error::class));
 
@@ -1293,7 +1293,7 @@ class PackageTest extends TestCase
         Monkey\Actions\expectDone($package2->hookName(Package::ACTION_PACKAGE_CONNECTED))
             ->once();
 
-        Monkey\Actions\expectDone($package2->hookName(Package::ACTION_FAILED_CONNECTION))
+        Monkey\Actions\expectDone($package2->hookName(Package::ACTION_FAILED_CONNECT))
             ->twice()
             ->with($package1->name(), \Mockery::type(\WP_Error::class));
 
@@ -1321,7 +1321,7 @@ class PackageTest extends TestCase
     {
         $package1 = $this->stubSimplePackage('1');
 
-        $action = $package1->hookName(Package::ACTION_FAILED_CONNECTION);
+        $action = $package1->hookName(Package::ACTION_FAILED_CONNECT);
         Monkey\Actions\expectDone($action)->never();
 
         static::assertFalse($package1->connect($package1));
@@ -1435,11 +1435,20 @@ class PackageTest extends TestCase
 
         $package = Package::new($this->stubProperties());
 
-        Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BUILD))
+        Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_ADD_MODULE))
             ->once()
             ->whenHappen(
                 static function (\Throwable $throwable) use ($exception, $package): void {
                     static::assertSame($exception, $throwable);
+                    static::assertTrue($package->statusIs(Package::STATUS_FAILED));
+                }
+            );
+
+        Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BUILD))
+            ->once()
+            ->whenHappen(
+                function (\Throwable $throwable) use ($package): void {
+                    $this->assertThrowableMessageMatches($throwable, 'build package');
                     static::assertTrue($package->statusIs(Package::STATUS_FAILED));
                 }
             );
@@ -1452,7 +1461,7 @@ class PackageTest extends TestCase
                     $previous = $throwable->getPrevious();
                     $this->assertThrowableMessageMatches($previous, 'build package');
                     $previous = $previous->getPrevious();
-                    $this->assertThrowableMessageMatches($previous, 'two');
+                    $this->assertThrowableMessageMatches($previous, 'add module');
                     static::assertSame($exception, $previous->getPrevious());
                     static::assertTrue($package->statusIs(Package::STATUS_FAILED));
                 }
@@ -1484,7 +1493,7 @@ class PackageTest extends TestCase
         $connected = Package::new($this->stubProperties());
         $connected->boot();
 
-        Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BUILD))
+        Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_ADD_MODULE))
             ->once()
             ->whenHappen(
                 static function (\Throwable $throwable) use ($exception, $package): void {

--- a/tests/unit/PackageTest.php
+++ b/tests/unit/PackageTest.php
@@ -30,7 +30,7 @@ class PackageTest extends TestCase
         static::assertTrue($package->hasReachedStatus(Package::STATUS_IDLE));
         static::assertFalse($package->hasReachedStatus(Package::STATUS_INITIALIZED));
         static::assertFalse($package->hasReachedStatus(Package::STATUS_BOOTING));
-        static::assertFalse($package->hasReachedStatus(Package::STATUS_READY));
+        static::assertFalse($package->hasReachedStatus(Package::STATUS_BOOTED));
         static::assertFalse($package->hasReachedStatus(Package::STATUS_DONE));
 
         $package->build();
@@ -39,13 +39,13 @@ class PackageTest extends TestCase
         static::assertTrue($package->hasReachedStatus(Package::STATUS_IDLE));
         static::assertTrue($package->hasReachedStatus(Package::STATUS_INITIALIZED));
         static::assertFalse($package->hasReachedStatus(Package::STATUS_BOOTING));
-        static::assertFalse($package->hasReachedStatus(Package::STATUS_READY));
+        static::assertFalse($package->hasReachedStatus(Package::STATUS_BOOTED));
         static::assertFalse($package->hasReachedStatus(Package::STATUS_DONE));
 
-        Monkey\Actions\expectDone($package->hookName(Package::ACTION_READY))
+        Monkey\Actions\expectDone($package->hookName(Package::ACTION_BOOTED))
             ->once()
             ->whenHappen(static function (Package $package): void {
-                static::assertTrue($package->statusIs(Package::STATUS_READY));
+                static::assertTrue($package->statusIs(Package::STATUS_BOOTED));
             });
 
         static::assertTrue($package->boot());
@@ -53,11 +53,11 @@ class PackageTest extends TestCase
         static::assertTrue($package->hasReachedStatus(Package::STATUS_IDLE));
         static::assertTrue($package->hasReachedStatus(Package::STATUS_INITIALIZED));
         static::assertTrue($package->hasReachedStatus(Package::STATUS_BOOTING));
-        static::assertTrue($package->hasReachedStatus(Package::STATUS_DONE));
-        // check back compat
         static::assertTrue($package->hasReachedStatus(Package::STATUS_BOOTED));
-        static::assertTrue($package->hasReachedStatus(Package::STATUS_MODULES_ADDED));
+        static::assertTrue($package->hasReachedStatus(Package::STATUS_DONE));
         static::assertFalse($package->hasReachedStatus(6));
+        // check back compat
+        static::assertTrue($package->hasReachedStatus(Package::STATUS_MODULES_ADDED));
 
         static::assertSame($expectedName, $package->name());
         static::assertInstanceOf(Properties::class, $package->properties());
@@ -105,10 +105,10 @@ class PackageTest extends TestCase
             $baseHookName . '.' . Package::ACTION_INIT,
         ];
 
-        yield 'ready' => [
-            Package::ACTION_READY,
+        yield 'booted' => [
+            Package::ACTION_BOOTED,
             $expectedName,
-            $baseHookName . '.' . Package::ACTION_READY,
+            $baseHookName . '.' . Package::ACTION_BOOTED,
         ];
     }
 
@@ -583,7 +583,7 @@ class PackageTest extends TestCase
             ->once()
             ->whenHappen(
                 static function (Package $package) use (&$log): void {
-                    static::assertTrue($package->statusIs(Package::STATUS_INIT));
+                    static::assertTrue($package->statusIs(Package::STATUS_INITIALIZING));
                     $log[] = 1;
                 }
             );
@@ -593,7 +593,7 @@ class PackageTest extends TestCase
             ->whenHappen(
                 static function (string $packageName, Package $package) use (&$log): void {
                     static::assertSame('package_1', $packageName);
-                    static::assertTrue($package->statusIs(Package::STATUS_INIT));
+                    static::assertTrue($package->statusIs(Package::STATUS_INITIALIZING));
                     $log[] = 2;
                 }
             );
@@ -607,11 +607,11 @@ class PackageTest extends TestCase
                 }
             );
 
-        Monkey\Actions\expectDone($package->hookName(Package::ACTION_READY))
+        Monkey\Actions\expectDone($package->hookName(Package::ACTION_BOOTED))
             ->once()
             ->whenHappen(
                 static function (Package $package) use (&$log): void {
-                    static::assertTrue($package->statusIs(Package::STATUS_READY));
+                    static::assertTrue($package->statusIs(Package::STATUS_BOOTED));
                     $log[] = 4;
                 }
             );
@@ -647,7 +647,7 @@ class PackageTest extends TestCase
             ->once()
             ->whenHappen(
                 static function (Package $package) use (&$log): void {
-                    static::assertTrue($package->statusIs(Package::STATUS_INIT));
+                    static::assertTrue($package->statusIs(Package::STATUS_INITIALIZING));
                     $log[] = 1;
                 }
             );
@@ -657,7 +657,7 @@ class PackageTest extends TestCase
             ->whenHappen(
                 static function (string $packageName, Package $package) use (&$log): void {
                     static::assertSame('package_1', $packageName);
-                    static::assertTrue($package->statusIs(Package::STATUS_INIT));
+                    static::assertTrue($package->statusIs(Package::STATUS_INITIALIZING));
                     $log[] = 2;
                 }
             );
@@ -671,11 +671,11 @@ class PackageTest extends TestCase
                 }
             );
 
-        Monkey\Actions\expectDone($package->hookName(Package::ACTION_READY))
+        Monkey\Actions\expectDone($package->hookName(Package::ACTION_BOOTED))
             ->once()
             ->whenHappen(
                 static function (Package $package) use (&$log): void {
-                    static::assertTrue($package->statusIs(Package::STATUS_READY));
+                    static::assertTrue($package->statusIs(Package::STATUS_BOOTED));
                     $log[] = 4;
                 }
             );
@@ -711,7 +711,7 @@ class PackageTest extends TestCase
             ->once()
             ->whenHappen(
                 static function (Package $package) use (&$log): void {
-                    static::assertTrue($package->statusIs(Package::STATUS_INIT));
+                    static::assertTrue($package->statusIs(Package::STATUS_INITIALIZING));
                     $log[] = 1;
                 }
             );
@@ -721,7 +721,7 @@ class PackageTest extends TestCase
             ->whenHappen(
                 static function (string $packageName, Package $package) use (&$log): void {
                     static::assertSame('package_1', $packageName);
-                    static::assertTrue($package->statusIs(Package::STATUS_INIT));
+                    static::assertTrue($package->statusIs(Package::STATUS_INITIALIZING));
                     $log[] = 2;
                 }
             );
@@ -735,7 +735,7 @@ class PackageTest extends TestCase
                 }
             );
 
-        Monkey\Actions\expectDone($package->hookName(Package::ACTION_READY))
+        Monkey\Actions\expectDone($package->hookName(Package::ACTION_BOOTED))
             ->never();
 
         $package->connect(Package::new($this->stubProperties('connected', true)));
@@ -757,7 +757,7 @@ class PackageTest extends TestCase
 
         Monkey\Actions\expectDone(Package::ACTION_MODULARITY_INIT)->never();
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_INITIALIZED))->never();
-        Monkey\Actions\expectDone($package->hookName(Package::ACTION_READY))->never();
+        Monkey\Actions\expectDone($package->hookName(Package::ACTION_BOOTED))->never();
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BUILD))->once();
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BOOT))->never();
 
@@ -777,7 +777,7 @@ class PackageTest extends TestCase
 
         Monkey\Actions\expectDone(Package::ACTION_MODULARITY_INIT)->never();
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_INITIALIZED))->never();
-        Monkey\Actions\expectDone($package->hookName(Package::ACTION_READY))->never();
+        Monkey\Actions\expectDone($package->hookName(Package::ACTION_BOOTED))->never();
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BUILD))->once();
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BOOT))->never();
 
@@ -798,7 +798,7 @@ class PackageTest extends TestCase
 
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_INIT))->once();
         Monkey\Actions\expectDone(Package::ACTION_MODULARITY_INIT)->once();
-        Monkey\Actions\expectDone($package->hookName(Package::ACTION_READY))->never();
+        Monkey\Actions\expectDone($package->hookName(Package::ACTION_BOOTED))->never();
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BUILD))->once();
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BOOT))->never();
 
@@ -813,7 +813,7 @@ class PackageTest extends TestCase
     {
         $package = Package::new($this->stubProperties('test', true));
 
-        Monkey\Actions\expectDone($package->hookName(Package::ACTION_READY))
+        Monkey\Actions\expectDone($package->hookName(Package::ACTION_BOOTED))
             ->once()
             ->whenHappen([$package, 'boot']);
 
@@ -840,7 +840,7 @@ class PackageTest extends TestCase
 
         Monkey\Actions\expectDone(Package::ACTION_MODULARITY_INIT)->never();
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_INITIALIZED))->never();
-        Monkey\Actions\expectDone($package->hookName(Package::ACTION_READY))->never();
+        Monkey\Actions\expectDone($package->hookName(Package::ACTION_BOOTED))->never();
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BUILD))->once();
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BOOT))->never();
 
@@ -861,7 +861,7 @@ class PackageTest extends TestCase
 
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_INIT))->once();
         Monkey\Actions\expectDone(Package::ACTION_MODULARITY_INIT)->once();
-        Monkey\Actions\expectDone($package->hookName(Package::ACTION_READY))->never();
+        Monkey\Actions\expectDone($package->hookName(Package::ACTION_BOOTED))->never();
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BUILD))->once();
         Monkey\Actions\expectDone($package->hookName(Package::ACTION_FAILED_BOOT))->never();
 
@@ -876,7 +876,7 @@ class PackageTest extends TestCase
     {
         $package = Package::new($this->stubProperties('test', true));
 
-        Monkey\Actions\expectDone($package->hookName(Package::ACTION_READY))
+        Monkey\Actions\expectDone($package->hookName(Package::ACTION_BOOTED))
             ->once()
             ->whenHappen([$package, 'build']);
 


### PR DESCRIPTION
## The new hook

The main scope for this PT was solving the problem in #47, that is, havign a "generic" hook that can be used to extend the package without previously holding an instance of the hook.

The reason for this are explained in the [comments to #47](https://github.com/inpsyde/modularity/issues/47#issuecomment-2124562269)

To quickly recap: when we want to perform something for all the packages of a given group, e.g. all project-specific plugin/themes/libraries without this hook the only way is to:
- make sure each package has a funcion that returns the package instance
- have a list of those functions (which has to be maintained manually)
- call `function_exists` befoe callign the function

This is hard to maintain and not particularly fast.

Having this hook, we can avoid all the 3 points above.


## Statuses and actions refactoring

When discussing the change above in #47, we found out that we had a pretty inconsistent way of dealing with actions hooks triggered because of status changes.

Moreover, we realized that the various status we had were not very consistent either with all the phases. For this reason [we agreed to](https://github.com/inpsyde/modularity/issues/47#issuecomment-2133235651):

- Extend the list of statuses
- Have a "map" between statuses and actions and a method to handle action triggering


## Additional improvements


### `PackageProxyContainer`

Thanks to the new statuses in this PR and to the new methods introced in #51 it was possible to improve the usage of `PackageProxyContainer`, basically avoiding its usage when the container is available.ù


### Packages connection

The improvend in this and previous PRs already improced package conections, making it more flexible and reliable.

In this PR another improvement is made. When a connection failed, an excption was eagerly thrown.

Take te scenario when a package:
1. at 'plugins_loaded' connects to another package
2. at 'wp_footer' uses services from the conntent packages to do something

Currently, if connection fails an exception would be thrown at step 1. But i the request is, for example, redirected or anyway terminates before 'wp_footer', there was no reason to throw and we could have avoided a runtime problem.

This is why now a failed connection emits a failure action (like before) and does not throw. If and when packages form teh connected package wll be accessed, the exeption will happen because services are missing having the connection failed. This way we delay failure as late as possible, but still is is possible to debug the reason for failure (e.g. my logging the "connection failed" action hook).


### Tests

A good number of unit tests are added to prove the various possible flows with combinations of `build()`, `boot()`, and `connect()`.


### Documentation

I took the chance to also add extensive inline documentation to explain the different parts of the bootstrapping flow, especially in the `Package` class, now it should be clear reading the code why anything does what it does.

The user documentation has also been extended for the new funcionalities and also reworked to be in general more clear.


## Notes

If merged, this PR not only closes #47 but also #45. The latter was attempting to solve "inconsistencies" in `build` and `boot` methods. Those inconsitencies where caused by two reasons: limitations in `PackageProxyContainer` which handled here and partly in #49 and #51, and the lack of aligned when `build()` was introduced, and that is fixed partly here and partly in #49.

In substance, merging this PR and the previous 2, all problems highlithed in #45 are also fixed. In fact, this PR contains a few tests that are very similar to the test proposed in #45

---

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature.

**What is the current behavior?** (You can also link to an open issue here)

See description.

**What is the new behavior (if this is a feature change)?**

See description.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.


**Other information**:

N/A.
