### PR TITLE
Avoid loading translations too early

### DIFF
--- a/docs/Properties.md
+++ b/docs/Properties.md
@@ -77,9 +77,8 @@ Additionally, PluginProperties will have the following public API:
 - `PluginProperties::isNetworkActive(): bool` - returns if the current Plugin is network-wide active.
 - `PluginProperties::isMuPlugin(): bool` - returns if the current Plugin is a must-use Plugin.
 
-Please note that to avoid triggering notices, our usage of `get_plugin_data` opts out of translations if called very early.
-Additionally, we disable HTML-safe text processing (via `wptexturize`) offered by default.
-These functions should not be used before the `'init'` hook which may be too late for some applications.
+Please note that our usage of `get_plugin_data` opts out of translations and HTML-safe text processing (via `wptexturize`) offered by default.
+These functions should not be used before the 'init' hook which may be too late for some applications.
 
 ## ThemeProperties
 

--- a/src/Properties/PluginProperties.php
+++ b/src/Properties/PluginProperties.php
@@ -54,12 +54,11 @@ class PluginProperties extends BaseProperties
             require_once ABSPATH . 'wp-admin/includes/plugin.php';
         }
 
-        // Avoid implicitly loading translations too early
-        // @see https://core.trac.wordpress.org/changeset/59127
-        $translate = did_action('after_setup_theme') || doing_action('after_setup_theme');
         // $markup = false, to avoid an incorrect early wptexturize call.
+        // $translate = false, to avoid loading translations too early
         // @see https://core.trac.wordpress.org/ticket/49965
-        $pluginData = (array) get_plugin_data($pluginMainFile, false, $translate);
+        // @see https://core.trac.wordpress.org/ticket/34114
+        $pluginData = (array) get_plugin_data($pluginMainFile, false, false);
         $properties = Properties::DEFAULT_PROPERTIES;
 
         // Map pluginData to internal structure.

--- a/tests/unit/Properties/PluginPropertiesTest.php
+++ b/tests/unit/Properties/PluginPropertiesTest.php
@@ -87,7 +87,6 @@ class PluginPropertiesTest extends TestCase
         $pluginMainFile = '/app/wp-content/plugins/plugin-dir/plugin-name.php';
         $expectedBaseName = 'plugin-dir/plugin-name.php';
 
-        Functions\expect('current_action')->andReturn('init');
         Functions\expect('get_plugin_data')->andReturn([
             'RequiresPlugins' => $requiresPlugins,
         ]);
@@ -292,57 +291,6 @@ class PluginPropertiesTest extends TestCase
                 '/wp-content/mu-plugins/the-plugin/index.php',
                 '/wp-content/mu-plugins/',
                 true,
-            ],
-        ];
-    }
-
-    /**
-     * @test
-     * @dataProvider provideTranslationLoadingData
-     *
-     * @param bool $didAfterSetupTheme
-     * @param bool $shouldTranslate
-     *
-     * @return void
-     */
-    public function testTranslationLoading(bool $didAfterSetupTheme, bool $shouldTranslate): void
-    {
-        $pluginMainFile = '/app/wp-content/plugins/plugin-dir/plugin-name.php';
-        $expectedBaseName = 'plugin-dir/plugin-name.php';
-        $expectedBasePath = '/app/wp-content/plugins/plugin-dir/';
-
-        $actualTranslate = false;
-
-        Functions\expect('did_action')->andReturn($didAfterSetupTheme);
-        Functions\expect('doing_action')->andReturn($didAfterSetupTheme);
-        Functions\expect('get_plugin_data')->andReturnUsing(
-            static function (string $file, bool $markup, bool $translate) use (&$actualTranslate): array {
-                $actualTranslate = $translate;
-                return [];
-            }
-        );
-        Functions\when('plugins_url')->returnArg(1);
-        Functions\when('wp_normalize_path')->returnArg(1);
-        Functions\expect('plugin_basename')->andReturn($expectedBaseName);
-        Functions\expect('plugin_dir_path')->andReturn($expectedBasePath);
-
-        PluginProperties::new($pluginMainFile);
-        static::assertSame($shouldTranslate, $actualTranslate);
-    }
-
-    /**
-     * @return \Generator
-     */
-    public static function provideTranslationLoadingData(): \Generator
-    {
-        yield from [
-            'is late hook' => [
-                true,
-                true,
-            ],
-            'is early hook' => [
-                false,
-                false,
             ],
         ];
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
WordPress 6.7 removed the need to `load_plugin_textdomain` manually.
In return, we receive a notice if translations are loaded/accessed too early.




**What is the new behavior (if this is a feature change)?**

Passing `$translate = false` in the call to `get_plugin_data` avoids the `_doing_it_wrong` and the resulting notice

Since `ExecutableModule` is responsible for hooking module logic into WordPress, it makes sense to bootstrap the package itself as early as feasible.
Hence, deferring bootstrap to `after_setup_thene` or `init` as proposed by core severely limits our flexibility in terms of what modules can to in the "remaining time"


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:
