### PR TITLE
Remove support for deprecated default modules

### DIFF
--- a/docs/Package.md
+++ b/docs/Package.md
@@ -171,7 +171,7 @@ $plugin->boot();
 static::assertTrue($myService->isBooted());
 ```
 
-### Deprecated boot parameters
+### Removed boot parameters
 
 Before Modularity v1.7.0, it was an accepted practice to pass default modules to `Package::boot()`,
 as in:
@@ -185,14 +185,17 @@ add_action(
 );
 ```
 
-This is now deprecated to allow a better separation of the "building" and "booting" steps.
+This is now removed to allow a better separation of the "building" and "booting" steps.
 
 While it still works (and it will work up to version 2.0), it will emit a deprecation notice.
 
 The replacement is using `Package::addModule()`:
 
 ```php
-plugin()->addModule(new ModuleOne())->addModule(new ModuleTwo())->boot();
+plugin()
+    ->addModule(new ModuleOne())
+    ->addModule(new ModuleTwo())
+    ->boot();
 ```
 
 There's only one case in which calling `Package::boot()` with default modules will throw an 

--- a/tests/unit/PackageTest.php
+++ b/tests/unit/PackageTest.php
@@ -233,29 +233,6 @@ class PackageTest extends TestCase
 
     /**
      * @test
-     * @runInSeparateProcess
-     */
-    public function testBootPassingModulesEmitDeprecation(): void
-    {
-        $module1 = $this->stubModule('module_1', ServiceModule::class);
-        $module1->allows('services')->andReturn($this->stubServices('service_1'));
-
-        $package = Package::new($this->stubProperties('test', true));
-
-        $this->convertDeprecationsToExceptions();
-        try {
-            $count = 0;
-            $package->boot($module1);
-        } catch (\Throwable $throwable) {
-            $count++;
-            $this->assertThrowableMessageMatches($throwable, 'boot().+?deprecated.+?1\.7');
-        } finally {
-            static::assertSame(1, $count);
-        }
-    }
-
-    /**
-     * @test
      */
     public function testAddModuleFailsAfterBuild(): void
     {
@@ -824,35 +801,6 @@ class PackageTest extends TestCase
     /**
      * @test
      */
-    public function testBuildPassingModulesToBoot(): void
-    {
-        $module1 = $this->stubModule('module_1', ServiceModule::class);
-        $module1->expects('services')->andReturn($this->stubServices('service_1'));
-
-        $module2 = $this->stubModule('module_2', ServiceModule::class);
-        $module2->expects('services')->andReturn($this->stubServices('service_2'));
-
-        $module3 = $this->stubModule('module_3', ServiceModule::class);
-        $module3->expects('services')->andReturn($this->stubServices('service_3'));
-
-        $package = Package::new($this->stubProperties('test', true))
-            ->addModule($module1)
-            ->addModule($module2)
-            ->build();
-
-        $this->ignoreDeprecations();
-        $package->boot($module2, $module3);
-
-        $container = $package->container();
-
-        static::assertSame('service_1', $container->get('service_1')['id']);
-        static::assertSame('service_2', $container->get('service_2')['id']);
-        static::assertSame('service_3', $container->get('service_3')['id']);
-    }
-
-    /**
-     * @test
-     */
     public function testBootFailsIfPassingNotAddedModulesAfterContainer(): void
     {
         $module1 = $this->stubModule('module_1', ServiceModule::class);
@@ -875,8 +823,7 @@ class PackageTest extends TestCase
         static::assertSame('service_2', $container->get('service_2')['id']);
 
         $this->expectExceptionMessageMatches("/can't add module module_3/i");
-        $this->ignoreDeprecations();
-        $package->boot($module2, $module3);
+        $package->addModule($module3);
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a follow-up (alternative) to #53.

Currently, this code results in failing tests. However, there was also a bug in the test logic, masking other issues. Considering that there was no change to production, except for the removal of default module handling in `boot`, I would argue that the expectations in some failing tests are incorrect, and should be reviewed and fixed.

**What is the current behavior?** (You can also link to an open issue here)

Default modules passed to the `boot` method are being handled.

**What is the new behavior (if this is a feature change)?**

The `boot` method does no longer support passing default modules.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



**Other information**:
