### PR TITLE
use wp-stubs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
         "phpstan/phpstan": "^2.1.1",
         "phpstan/phpstan-mockery": "^2.0.0",
         "phpstan/phpstan-phpunit": "^2.0.4",
-        "szepeviktor/phpstan-wordpress": "^2",
         "swissspidy/phpstan-no-private": "^v1.0.0",
-        "phpstan/phpstan-deprecation-rules": "^2.0.1"
+        "phpstan/phpstan-deprecation-rules": "^2.0.1",
+        "inpsyde/wp-stubs-versions": "dev-latest"
     },
     "extra": {
         "branch-alias": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,9 +3,12 @@ includes:
     - vendor/phpstan/phpstan-mockery/extension.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/swissspidy/phpstan-no-private/rules.neon
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
     level: 8
+    dynamicConstantNames:
+        - WP_DEBUG
+    scanFiles:
+        - vendor/inpsyde/wp-stubs-versions/latest.php
     paths:
         - src/
         - tests/


### PR DESCRIPTION
PR into `feature/phpstan` branch, replacing the `phpstan-wordpress` extension with `wp-stubs`.